### PR TITLE
Refactor tests to validate YAML and shaders

### DIFF
--- a/tests/graph_samples.py
+++ b/tests/graph_samples.py
@@ -1,0 +1,56 @@
+from core.node import Node
+import yaml
+
+
+def basic_color_graph():
+    surface = Node("surface")
+    fragment_pass = surface.get_node_by_type("fragment_pass")
+    fragment_output = surface.find_nested_node_by_type(fragment_pass, "fragment_output")
+    color = surface.create_node("color", fragment_pass)
+    surface.connect_nodes(color, fragment_output, 0, 0)
+    return surface, fragment_pass, fragment_output, color
+
+
+def addition_graph():
+    surface = Node("surface")
+    fragment_pass = surface.get_node_by_type("fragment_pass")
+    fragment_output = surface.find_nested_node_by_type(fragment_pass, "fragment_output")
+    color_a = surface.create_node("color", fragment_pass)
+    color_b = surface.create_node("color", fragment_pass)
+    add_node = surface.create_node("add", fragment_pass)
+    surface.connect_nodes(color_a, add_node, 0, 0)
+    surface.connect_nodes(color_b, add_node, 0, 1)
+    surface.connect_nodes(add_node, fragment_output, 0, 0)
+    return surface, fragment_pass, fragment_output, color_a, color_b, add_node
+
+
+def float_graph():
+    surface = Node("surface")
+    fragment_pass = surface.get_node_by_type("fragment_pass")
+    fragment_output = surface.find_nested_node_by_type(fragment_pass, "fragment_output")
+    float_node = surface.create_node("float", fragment_pass)
+    surface.connect_nodes(float_node, fragment_output, 0, 1)
+    return surface, fragment_pass, fragment_output, float_node
+
+
+def meta_graph():
+    surface, fragment_pass, fragment_output, color = basic_color_graph()
+    surface.add_meta("blend_mode_transparent")
+    return surface, fragment_pass, fragment_output, color
+
+def external_graph(tmp_path):
+    external = Node("color")
+    external_path = tmp_path / "external.yml"
+    with open(external_path, "w") as f:
+        yaml.dump(external.to_dict(), f, default_flow_style=False, sort_keys=False)
+    surface = Node("surface")
+    initial_count = len(surface.graph_data["nodes"])
+    surface.create_external_node(str(external_path))
+    return surface, initial_count
+
+
+def vertex_color_graph():
+    surface = Node("surface")
+    vertex_pass = surface.get_node_by_type("vertex_pass")
+    color = surface.create_node("color", vertex_pass)
+    return surface, vertex_pass, color

--- a/tests/test_graph_yaml.py
+++ b/tests/test_graph_yaml.py
@@ -1,69 +1,45 @@
 import yaml
 
-from core.node import Node
+from tests.graph_samples import (
+    addition_graph,
+    basic_color_graph,
+    external_graph,
+    meta_graph,
+    vertex_color_graph,
+)
 
 
-def test_basic_color_graph_yaml(surface_graph):
-    surface, fragment_pass, fragment_output = surface_graph
+def test_basic_color_graph_yaml():
+    surface, fragment_pass, fragment_output, color = basic_color_graph()
 
-    color = surface.create_node("color", fragment_pass)
-    surface.connect_nodes(color, fragment_output, 0, 0)
-
-    # Ensure the color node exists in the fragment pass
     child_types = [n["type"] for n in fragment_pass["nodes"]]
     assert "color" in child_types
-
-    # Validate the connection in the YAML data
     assert fragment_output["inputs"][0]["value"] == f"../{color['id']}/0"
 
 
-def test_addition_graph_yaml(surface_graph):
-    surface, fragment_pass, fragment_output = surface_graph
-
-    color_a = surface.create_node("color", fragment_pass)
-    color_b = surface.create_node("color", fragment_pass)
-    add_node = surface.create_node("add", fragment_pass)
-
-    surface.connect_nodes(color_a, add_node, 0, 0)
-    surface.connect_nodes(color_b, add_node, 0, 1)
-    surface.connect_nodes(add_node, fragment_output, 0, 0)
+def test_addition_graph_yaml():
+    surface, fragment_pass, fragment_output, color_a, color_b, add_node = addition_graph()
 
     assert add_node["inputs"][0]["value"] == f"../{color_a['id']}/0"
     assert add_node["inputs"][1]["value"] == f"../{color_b['id']}/0"
     assert fragment_output["inputs"][0]["value"] == f"../{add_node['id']}/0"
 
 
-def test_external_graph_yaml(surface_graph, tmp_path):
-    external_graph = Node("color")
-    external_path = tmp_path / "external.yml"
-    with open(external_path, "w") as f:
-        yaml.dump(
-            external_graph.to_dict(),
-            f,
-            default_flow_style=False,
-            sort_keys=False,
-        )
-
-    surface, _, _ = surface_graph
-    initial_count = len(surface.graph_data["nodes"])
-    surface.create_external_node(str(external_path))
+def test_external_graph_yaml(tmp_path):
+    surface, initial_count = external_graph(tmp_path)
 
     assert len(surface.graph_data["nodes"]) == initial_count + 1
     assert surface.graph_data["nodes"][-1]["type"] == "color"
 
 
-def test_nested_vertex_graph_yaml(surface_graph):
-    surface, _, _ = surface_graph
-    vertex_pass = surface.get_node_by_type("vertex_pass")
-    color = surface.create_node("color", vertex_pass)
+def test_nested_vertex_graph_yaml():
+    surface, vertex_pass, color = vertex_color_graph()
     nested = surface.find_nested_node_by_type(vertex_pass, "color")
     assert nested is not None
     assert nested["id"] == color["id"]
 
 
-def test_node_meta(surface_graph):
-    surface, _, _ = surface_graph
-    surface.add_meta({"author": "tester"})
-    surface.add_meta("final")
-    assert surface.graph_data["meta"] == [{"author": "tester"}, "final"]
+def test_node_meta_yaml():
+    surface, _, _, _ = meta_graph()
+    assert surface.graph_data["meta"] == ["blend_mode_transparent"]
 

--- a/tests/test_shader_generation.py
+++ b/tests/test_shader_generation.py
@@ -2,15 +2,12 @@ import re
 import shutil
 import yaml
 
-from core.node import Node
 from build_shader import build
+from tests.graph_samples import addition_graph, basic_color_graph, float_graph, meta_graph
 
 
-def test_godot_color_shader(surface_graph, compile_graph):
-    surface, fragment_pass, fragment_output = surface_graph
-
-    color = surface.create_node("color", fragment_pass)
-    surface.connect_nodes(color, fragment_output, 0, 0)
+def test_godot_color_shader(compile_graph):
+    surface, _, _, color = basic_color_graph()
 
     shader_code = compile_graph(surface.to_dict(), "data/languages/Godot.yml")
 
@@ -19,11 +16,8 @@ def test_godot_color_shader(surface_graph, compile_graph):
     assert re.search(r"ALBEDO = vec3\(\(color_\d+\)\.rgb\);", shader_code)
 
 
-def test_unity_color_shader(surface_graph, compile_graph):
-    surface, fragment_pass, fragment_output = surface_graph
-
-    color = surface.create_node("color", fragment_pass)
-    surface.connect_nodes(color, fragment_output, 0, 0)
+def test_unity_color_shader(compile_graph):
+    surface, _, _, color = basic_color_graph()
 
     shader_code = compile_graph(surface.to_dict(), "data/languages/Unity.yml")
 
@@ -31,15 +25,8 @@ def test_unity_color_shader(surface_graph, compile_graph):
     assert re.search(r"o.Albedo = float3\(\(color_\d+\)\.rgb\);", shader_code)
 
 
-def test_godot_addition_shader(surface_graph, compile_graph):
-    surface, fragment_pass, fragment_output = surface_graph
-    color_a = surface.create_node("color", fragment_pass)
-    color_b = surface.create_node("color", fragment_pass)
-    add_node = surface.create_node("add", fragment_pass)
-
-    surface.connect_nodes(color_a, add_node, 0, 0)
-    surface.connect_nodes(color_b, add_node, 0, 1)
-    surface.connect_nodes(add_node, fragment_output, 0, 0)
+def test_godot_addition_shader(compile_graph):
+    surface, _, fragment_output, color_a, color_b, add_node = addition_graph()
 
     shader_code = compile_graph(surface.to_dict(), "data/languages/Godot.yml")
 
@@ -47,11 +34,8 @@ def test_godot_addition_shader(surface_graph, compile_graph):
     assert re.search(r"ALBEDO = vec3\(\(add_\d+\)\.rgb\);", shader_code)
 
 
-def test_godot_float_shader_file(surface_graph, tmp_path, monkeypatch):
-    surface, fragment_pass, fragment_output = surface_graph
-
-    roughness = surface.create_node("float", fragment_pass)
-    surface.connect_nodes(roughness, fragment_output, 0, 1)
+def test_godot_float_shader_file(tmp_path, monkeypatch):
+    surface, _, _, float_node = float_graph()
 
     graph_path = tmp_path / "float_graph.yml"
     with open(graph_path, "w") as f:
@@ -67,4 +51,16 @@ def test_godot_float_shader_file(surface_graph, tmp_path, monkeypatch):
     shader_code = shader_file.read_text()
     assert re.search(r"float float_\d+ = 0.0;", shader_code)
     assert re.search(r"ROUGHNESS = float_\d+;", shader_code)
+
+
+def test_meta_godot_shader(compile_graph):
+    surface, _, _, _ = meta_graph()
+    shader_code = compile_graph(surface.to_dict(), "data/languages/Godot.yml")
+    assert "render_mode blend_mix;" in shader_code
+
+
+def test_meta_unity_shader(compile_graph):
+    surface, _, _, _ = meta_graph()
+    shader_code = compile_graph(surface.to_dict(), "data/languages/Unity.yml")
+    assert 'Tags { "Queue" = "Transparent" }' in shader_code
 


### PR DESCRIPTION
## Summary
- add reusable graph builder helpers for tests
- consolidate YAML tests to use shared graph builders and check meta info
- verify compiled shaders for meta, addition, float graphs using shared builders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae15a76bd08332a976825045278f42