### PR TITLE
Remove Godot headless validation from tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,5 @@
 import sys
 import shutil
-import subprocess
-import urllib.request
-import zipfile
-import platform
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -18,94 +14,6 @@ from core.graph_compiler import GraphCompiler
 
 
 SHADERS_DIR = ROOT / "tests" / "shaders"
-ENGINES_DIR = ROOT / "tests" / "engines"
-ENGINE_VERSIONS = {"godot": "4.4.1-stable"}
-
-
-_GODOT_CACHE = None
-
-
-def ensure_godot():
-    """Ensure a headless Godot binary is available for the host platform."""
-    global _GODOT_CACHE
-    if _GODOT_CACHE is not None:
-        return _GODOT_CACHE
-
-    engine_dir = ENGINES_DIR / "godot"
-    engine_dir.mkdir(parents=True, exist_ok=True)
-    version = ENGINE_VERSIONS["godot"]
-
-    system = platform.system().lower()
-    if system == "linux":
-        zip_name = f"Godot_v{version}_linux.x86_64.zip"
-        binary = engine_dir / f"Godot_v{version}_linux.x86_64"
-    elif system == "darwin":
-        zip_name = f"Godot_v{version}_macos.universal.zip"
-        binary = engine_dir / "Godot.app" / "Contents" / "MacOS" / "Godot"
-    elif system.startswith("win"):
-        zip_name = f"Godot_v{version}_win64.exe.zip"
-        binary = engine_dir / f"Godot_v{version}_win64.exe"
-    else:
-        raise RuntimeError(f"Unsupported platform for Godot download: {system}")
-
-    if not binary.exists():
-        url = (
-            "https://github.com/godotengine/godot/releases/download/"
-            f"{version}/{zip_name}"
-        )
-        zip_path = engine_dir / "godot.zip"
-        try:
-            urllib.request.urlretrieve(url, zip_path)
-            with zipfile.ZipFile(zip_path) as zf:
-                zf.extractall(engine_dir)
-            if not binary.exists():
-                raise RuntimeError("Godot binary not found after extraction")
-            if system in {"linux", "darwin"}:
-                binary.chmod(0o755)
-        except Exception as exc:
-            raise RuntimeError(f"Failed to download Godot {version}: {exc}")
-        finally:
-            if zip_path.exists():
-                zip_path.unlink()
-
-    script = engine_dir / "godot_compile_shader.gd"
-    script.write_text(
-        (
-            """
-extends SceneTree
-
-func _init():
-    var args = OS.get_cmdline_args()
-    if args.size() == 0:
-        push_error("No shader file provided")
-        quit(1)
-        return
-    var shader_path = args[0]
-    var code = FileAccess.get_file_as_string(shader_path)
-    var shader = Shader.new()
-    shader.code = code
-    quit()
-"""
-        ).strip()
-    )
-
-    _GODOT_CACHE = (binary, script)
-    return _GODOT_CACHE
-
-
-def compile_with_godot(shader_path: Path) -> None:
-    """Compile a shader using the headless Godot binary."""
-    binary, script = ensure_godot()
-    proc = subprocess.run(
-        [str(binary), "--headless", "-s", str(script), str(shader_path)],
-        capture_output=True,
-        text=True,
-    )
-    if proc.returncode != 0 or "Error" in proc.stderr or "ERROR" in proc.stderr:
-        raise RuntimeError(f"Godot failed to compile {shader_path}:\n{proc.stderr}")
-
-
-ENGINE_COMPILERS = {"godot": compile_with_godot}
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -141,10 +49,7 @@ def compile_graph():
         out_file = out_dir / f"{name}.{ext}"
         out_file.write_text(compiler.result_code)
 
-        compiler_fn = ENGINE_COMPILERS.get(engine)
-        if compiler_fn:
-            compiler_fn(out_file)
-
         return compiler.result_code
 
     return _compile
+


### PR DESCRIPTION
## Summary
- remove headless Godot shader validation
- keep shader output generation for manual review

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af23d884e083329e4b42b6b21205fb