### PR TITLE
Skip default shader outputs

### DIFF
--- a/core/graph_compiler.py
+++ b/core/graph_compiler.py
@@ -2,6 +2,8 @@
 import re
 from pprint import pprint
 
+from .node import Node
+
 
 def log(logs, separated=True):
     if separated:
@@ -122,6 +124,38 @@ class GraphCompiler:
             input_index = int(input_index)
             node['_resolving_input'] = True
             self.resolve_template_input(node, match, input_index)
+
+        if not node.get('outputs'):
+            self.remove_default_inputs(node)
+
+    def remove_default_inputs(self, node):
+        """Remove code lines for inputs left at their default values."""
+        Node._load_templates()
+        template = Node._templates.get(node['type'])
+        if not template:
+            return
+
+        defaults = {inp['name']: inp['value'] for inp in template.get('inputs', [])}
+        lines = node['_code'].split('\n')
+        new_lines = []
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                new_lines.append(line)
+                continue
+            prop = stripped.split('=')[0].strip()
+            input_pin = next((i for i in node.get('inputs', []) if i['name'] == prop), None)
+            default_val = defaults.get(prop)
+            if not input_pin or default_val is None:
+                new_lines.append(line)
+                continue
+            value = input_pin['value']
+            if isinstance(value, str) and '../' in value:
+                new_lines.append(line)
+                continue
+            if value != default_val:
+                new_lines.append(line)
+        node['_code'] = '\n'.join(new_lines)
 
     def resolve_internals(self, node):
         node['_code'] = self.get_template(node)

--- a/tests/test_shader_generation.py
+++ b/tests/test_shader_generation.py
@@ -25,6 +25,11 @@ def test_godot_color_shader(compile_graph):
     assert "shader_type spatial;" in shader_code
     assert re.search(r"vec4 color_\d+ = vec4\(1.0, 1.0, 1.0, 1.0\);", shader_code)
     assert re.search(r"ALBEDO = vec3\(color_\d+\.rgb\);", shader_code)
+    assert "ROUGHNESS" not in shader_code
+    assert "METALLIC" not in shader_code
+    assert "EMISSION" not in shader_code
+    assert "NORMAL" not in shader_code
+    assert "ALPHA" not in shader_code
     out_file = Path(__file__).parent / "shaders" / "godot" / "basic_color.gdshader"
     assert out_file.exists()
 


### PR DESCRIPTION
## Summary
- avoid emitting shader lines for any output pins left at their default values
- assert Godot shaders omit unused fragment features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af26bec3cc8332850e2e1a4bef60e3