### PR TITLE
refactor: modularize application lifecycle

### DIFF
--- a/src/core/lifecycle/compileGraph.ts
+++ b/src/core/lifecycle/compileGraph.ts
@@ -1,0 +1,11 @@
+import type { LifecycleContext } from "./types";
+import { GraphCompiler } from "../compiler/graphCompiler";
+import { loadLanguage } from "../schema/registry";
+import type { Graph } from "../graph/types";
+
+export async function compileGraph(ctx: LifecycleContext<any, Graph>): Promise<string> {
+  const lang = await loadLanguage("ThreeJS_GLSL.json");
+  const compiler = new GraphCompiler(ctx.graph as Graph, lang);
+  compiler.compile();
+  return compiler.result_code;
+}

--- a/src/core/lifecycle/index.ts
+++ b/src/core/lifecycle/index.ts
@@ -1,0 +1,7 @@
+export * from "./types";
+export * from "./run";
+export { initializeWindows } from "./initialize";
+export { loadExampleGraphs } from "./loadExamples";
+export { provideGraphData } from "./provideGraphData";
+export { compileGraph } from "./compileGraph";
+export { updatePreview } from "./updatePreview";

--- a/src/core/lifecycle/initialize.ts
+++ b/src/core/lifecycle/initialize.ts
@@ -1,0 +1,5 @@
+import type { LifecycleContext } from "./types";
+
+export async function initializeWindows(_ctx: LifecycleContext): Promise<void> {
+  // placeholder for window or UI initialization
+}

--- a/src/core/lifecycle/loadExamples.ts
+++ b/src/core/lifecycle/loadExamples.ts
@@ -1,0 +1,16 @@
+import type { LifecycleContext } from "./types";
+import type { Graph } from "../graph/types";
+import { promises as fs } from "fs";
+import path from "path";
+
+export async function loadExampleGraphs(_ctx: LifecycleContext): Promise<Graph[]> {
+  const dir = path.resolve(process.cwd(), "examples");
+  const files = await fs.readdir(dir);
+  const graphs: Graph[] = [];
+  for (const f of files) {
+    if (!f.endsWith(".json")) continue;
+    const raw = await fs.readFile(path.join(dir, f), "utf8");
+    graphs.push(JSON.parse(raw));
+  }
+  return graphs;
+}

--- a/src/core/lifecycle/provideGraphData.ts
+++ b/src/core/lifecycle/provideGraphData.ts
@@ -1,0 +1,9 @@
+import type { LifecycleContext } from "./types";
+import type { Graph } from "../graph/types";
+
+export async function provideGraphData(ctx: LifecycleContext<Graph[]>): Promise<Graph> {
+  const [first] = ctx.examples ?? [];
+  const surface = first?.nodes?.[0];
+  if (!surface) throw new Error("No surface node found in examples");
+  return surface as Graph;
+}

--- a/src/core/lifecycle/run.ts
+++ b/src/core/lifecycle/run.ts
@@ -1,0 +1,13 @@
+import type { AppLifecycleHooks, LifecycleContext } from "./types";
+
+export async function runAppLifecycle<Examples, GraphData, Code, Preview>(
+  hooks: AppLifecycleHooks<Examples, GraphData, Code, Preview>
+): Promise<LifecycleContext<Examples, GraphData, Code, Preview>> {
+  const ctx: LifecycleContext<Examples, GraphData, Code, Preview> = {};
+  if (hooks.initializeWindows) await hooks.initializeWindows(ctx);
+  ctx.examples = await hooks.loadExampleGraphs(ctx);
+  ctx.graph = await hooks.provideGraphData(ctx);
+  ctx.code = await hooks.compileGraph(ctx);
+  ctx.preview = await hooks.updatePreview(ctx);
+  return ctx;
+}

--- a/src/core/lifecycle/types.ts
+++ b/src/core/lifecycle/types.ts
@@ -1,0 +1,19 @@
+export interface LifecycleContext<Examples = unknown, GraphData = unknown, Code = string, Preview = unknown> {
+  examples?: Examples;
+  graph?: GraphData;
+  code?: Code;
+  preview?: Preview;
+}
+
+export interface AppLifecycleHooks<Examples = unknown, GraphData = unknown, Code = string, Preview = unknown> {
+  /** Initialize application windows or UI containers. */
+  initializeWindows?: (ctx: LifecycleContext<Examples, GraphData, Code, Preview>) => Promise<void> | void;
+  /** Load example graphs from disk or remote endpoint. */
+  loadExampleGraphs: (ctx: LifecycleContext<Examples, GraphData, Code, Preview>) => Promise<Examples>;
+  /** Convert the loaded examples into canonical graph data. */
+  provideGraphData: (ctx: LifecycleContext<Examples, GraphData, Code, Preview>) => Promise<GraphData> | GraphData;
+  /** Compile the graph data into a GLSL shader source. */
+  compileGraph: (ctx: LifecycleContext<Examples, GraphData, Code, Preview>) => Promise<Code>;
+  /** Update the preview panel using the compiled GLSL code. */
+  updatePreview: (ctx: LifecycleContext<Examples, GraphData, Code, Preview>) => Promise<Preview>;
+}

--- a/src/core/lifecycle/updatePreview.ts
+++ b/src/core/lifecycle/updatePreview.ts
@@ -1,0 +1,6 @@
+import type { LifecycleContext } from "./types";
+import { parseUniformsAndSanitize, type ParsedShader } from "../preview/shaderUtils";
+
+export async function updatePreview(ctx: LifecycleContext<any, any, string>): Promise<ParsedShader> {
+  return parseUniformsAndSanitize(ctx.code ?? "");
+}

--- a/tests/lifecycle.spec.ts
+++ b/tests/lifecycle.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  runAppLifecycle,
+  type AppLifecycleHooks,
+  initializeWindows,
+  loadExampleGraphs,
+  provideGraphData,
+  compileGraph,
+  updatePreview,
+} from "../src/core/lifecycle";
+
+describe("app lifecycle", () => {
+  it("runs all lifecycle steps in order with context propagation", async () => {
+    const calls: string[] = [];
+    const hooks: AppLifecycleHooks<string[], string, string, number> = {
+      initializeWindows: vi.fn(async (ctx) => { calls.push("init"); expect(ctx.examples).toBeUndefined(); }),
+      loadExampleGraphs: vi.fn(async (ctx) => { calls.push("load"); expect(ctx.examples).toBeUndefined(); return ["example"]; }),
+      provideGraphData: vi.fn(async (ctx) => { calls.push("provide"); expect(ctx.examples).toEqual(["example"]); return "graph"; }),
+      compileGraph: vi.fn(async (ctx) => { calls.push("compile"); expect(ctx.graph).toBe("graph"); return "glsl"; }),
+      updatePreview: vi.fn(async (ctx) => { calls.push("update"); expect(ctx.code).toBe("glsl"); return 42; }),
+    };
+    const ctx = await runAppLifecycle(hooks);
+    expect(calls).toEqual(["init", "load", "provide", "compile", "update"]);
+    expect(ctx).toEqual({ examples: ["example"], graph: "graph", code: "glsl", preview: 42 });
+    expect(hooks.initializeWindows).toHaveBeenCalledTimes(1);
+    expect(hooks.loadExampleGraphs).toHaveBeenCalledTimes(1);
+    expect(hooks.provideGraphData).toHaveBeenCalledTimes(1);
+    expect(hooks.compileGraph).toHaveBeenCalledTimes(1);
+    expect(hooks.updatePreview).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads, compiles and prepares preview for example graphs", async () => {
+    const ctx = await runAppLifecycle({
+      initializeWindows,
+      loadExampleGraphs,
+      provideGraphData,
+      compileGraph,
+      updatePreview,
+    });
+    expect(Array.isArray(ctx.examples)).toBe(true);
+    expect(ctx.graph).toBeTruthy();
+    expect(typeof ctx.code).toBe("string");
+    expect(ctx.code).toMatch(/void\s+main/);
+    expect(ctx.preview.fragment).toMatch(/gl_FragColor/);
+  });
+});


### PR DESCRIPTION
## Summary
- restructure lifecycle into context-driven pipeline with explicit hook types
- add default steps for loading example graphs, compiling, and preview sanitation
- expand lifecycle tests to cover context flow and sample graph compilation

## Testing
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68becaeb2c5083329fcd7359559b357c