### PR TITLE
refactor: remove redundant panel headers

### DIFF
--- a/src/components/CompilePanel.tsx
+++ b/src/components/CompilePanel.tsx
@@ -173,8 +173,7 @@ export function CompilePanel({ graph, className, variant = "overlay" }: CompileP
   if (variant === "docked") {
     return (
       <Card className={cn("h-full flex flex-col", className)}>
-        <CardHeader className="py-3 px-4 flex flex-row items-center justify-between">
-          <CardTitle className="text-sm">Compile Output</CardTitle>
+        <CardHeader className="py-3 px-4 flex flex-row items-center justify-end">
           <div className="flex items-center gap-2">
             <div className="min-w-[140px]">
               <Select value={language} onValueChange={setLanguage}>

--- a/src/components/GraphDataPanel.tsx
+++ b/src/components/GraphDataPanel.tsx
@@ -40,8 +40,7 @@ function GraphDataPanelDocked({ data, className }: { data: unknown; className?: 
   }, [pretty]);
   return (
     <Card className={cn("h-full flex flex-col", className)}>
-      <CardHeader className="py-3 px-4 flex flex-row items-center justify-between">
-        <CardTitle className="text-sm">Graph Data</CardTitle>
+      <CardHeader className="py-3 px-4 flex flex-row items-center justify-end">
         <div className="flex items-center gap-2">
           <Button size="icon" variant="ghost" aria-label="Copy graph data" title="Copy" onClick={copyToClipboard} disabled={!pretty}>
             {copied ? <Check className="size-4" /> : <Copy className="size-4" />}

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -307,8 +307,7 @@ export function PreviewPanel({ graph, className, variant = "overlay" }: PreviewP
   if (variant === "docked") {
     return (
       <Card className={cn("h-full flex flex-col", className)}>
-        <CardHeader className="py-3 px-4 flex flex-row items-center justify-between">
-          <CardTitle className="text-sm">3D Preview</CardTitle>
+        <CardHeader className="py-3 px-4 flex flex-row items-center justify-end">
           <div className="flex items-center gap-2">
             <div className="min-w-[120px]">
               <Select value={primitive} onValueChange={(v) => setPrimitive(v as Primitive)}>

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -170,9 +170,6 @@ export function PropertiesPanel({ className, variant = "docked" }: PropertiesPan
   if (variant === "docked") {
     return (
       <Card className={cn("h-full flex flex-col", className)}>
-        <CardHeader className="py-3 px-4 flex flex-row items-center justify-between">
-          <CardTitle className="text-sm">Properties</CardTitle>
-        </CardHeader>
         <CardContent className="px-4 pb-4 flex-1 overflow-auto">{body}</CardContent>
       </Card>
     );


### PR DESCRIPTION
## Summary
- drop repeated headers from docked panels for a cleaner tab interface

## Testing
- `bun run lint`
- `bun run test`
- `bun run test:e2e` *(fails: Script not found "test:e2e")*

------
https://chatgpt.com/codex/tasks/task_e_68bfe8168c44833294ee50d82d4eae95