### PR TITLE
feat: enhance code panels with syntax highlighting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.475.0",
+        "prism-react-renderer": "^2.4.1",
         "react": "^19",
         "react-colorful": "^5.6.1",
         "react-dom": "^19",
@@ -255,6 +256,8 @@
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/node": ["@types/node@22.18.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw=="],
+
+    "@types/prismjs": ["@types/prismjs@1.26.5", "", {}, "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ=="],
 
     "@types/react": ["@types/react@19.1.12", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w=="],
 
@@ -669,6 +672,8 @@
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prism-react-renderer": ["prism-react-renderer@2.4.1", "", { "dependencies": { "@types/prismjs": "^1.26.0", "clsx": "^2.0.0" }, "peerDependencies": { "react": ">=16.0.0" } }, "sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig=="],
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-slot": "^1.1.2",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@xyflow/react": "^12.8.4",
     "bun-plugin-tailwind": "^0.0.14",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.475.0",
+    "prism-react-renderer": "^2.4.1",
     "react": "^19",
     "react-colorful": "^5.6.1",
     "react-dom": "^19",
@@ -31,7 +33,6 @@
     "tailwindcss": "^4.0.6",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.170.0",
-    "@radix-ui/react-tabs": "^1.1.13",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { default as Highlight, type Language } from "prism-react-renderer";
-import githubTheme from "prism-react-renderer/themes/github";
+import Highlight, { themes, type Language } from "prism-react-renderer";
 import { cn } from "@/lib/utils";
 
 export type CodeBlockProps = {
@@ -11,7 +10,7 @@ export type CodeBlockProps = {
 
 export function CodeBlock({ code, language, className }: CodeBlockProps) {
   return (
-    <Highlight theme={githubTheme} code={code} language={language as Language}>
+    <Highlight theme={themes.github} code={code} language={language as Language}>
       {({ className: cls, style, tokens, getLineProps, getTokenProps }) => (
         <pre
           className={cn(

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Highlight, { themes, type Language } from "prism-react-renderer";
+import { Highlight, themes, type Language } from "prism-react-renderer";
 import { cn } from "@/lib/utils";
 
 export type CodeBlockProps = {

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import Highlight, { themes } from "prism-react-renderer";
+import { default as Highlight, type Language } from "prism-react-renderer";
+import githubTheme from "prism-react-renderer/themes/github";
 import { cn } from "@/lib/utils";
 
 export type CodeBlockProps = {
@@ -10,7 +11,7 @@ export type CodeBlockProps = {
 
 export function CodeBlock({ code, language, className }: CodeBlockProps) {
   return (
-    <Highlight theme={themes.github} code={code} language={language}>
+    <Highlight theme={githubTheme} code={code} language={language as Language}>
       {({ className: cls, style, tokens, getLineProps, getTokenProps }) => (
         <pre
           className={cn(

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Highlight, themes } from "prism-react-renderer";
+import Highlight, { themes } from "prism-react-renderer";
 import { cn } from "@/lib/utils";
 
 export type CodeBlockProps = {

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Highlight, themes } from "prism-react-renderer";
+import { cn } from "@/lib/utils";
+
+export type CodeBlockProps = {
+  code: string;
+  language: string;
+  className?: string;
+};
+
+export function CodeBlock({ code, language, className }: CodeBlockProps) {
+  return (
+    <Highlight theme={themes.github} code={code} language={language}>
+      {({ className: cls, style, tokens, getLineProps, getTokenProps }) => (
+        <pre
+          className={cn(
+            cls,
+            "text-xs leading-relaxed whitespace-pre-wrap break-words overflow-auto rounded-md bg-muted p-2",
+            className
+          )}
+          style={style}
+        >
+          {tokens.map((line, i) => (
+            <div key={i} {...getLineProps({ line })}>
+              {line.map((token, key) => (
+                <span key={key} {...getTokenProps({ token })} />
+              ))}
+            </div>
+          ))}
+        </pre>
+      )}
+    </Highlight>
+  );
+}
+
+export default CodeBlock;
+

--- a/src/components/CompilePanel.tsx
+++ b/src/components/CompilePanel.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Card } from "./ui/card";
 import { Button } from "./ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 import { cn } from "@/lib/utils";
 import { isAbortError } from "@/lib/errors";
 import { isCompilableGraph } from "@/core/io/guards";
 import { Check, Copy } from "lucide-react";
+import CodeBlock from "./CodeBlock";
 
 type CompilePanelProps = {
   graph: unknown;
@@ -14,6 +15,15 @@ type CompilePanelProps = {
 };
 
 type LanguageItem = { key: string; name: string; path: string };
+
+const getPrismLang = (key: string): string => {
+  const lower = key.toLowerCase();
+  if (lower.includes("json")) return "json";
+  if (lower.includes("glsl")) return "clike";
+  if (lower.includes("wgsl")) return "clike";
+  if (lower.includes("metal")) return "clike";
+  return "clike";
+};
 
 export function CompilePanel({ graph, className, variant = "overlay" }: CompilePanelProps) {
   const [collapsed, setCollapsed] = useState(false);
@@ -171,50 +181,51 @@ export function CompilePanel({ graph, className, variant = "overlay" }: CompileP
   };
 
   if (variant === "docked") {
+    const display = working ? "Compiling…" : error || code;
+    const lang = error ? "text" : getPrismLang(language);
     return (
-      <Card className={cn("h-full flex flex-col", className)}>
-        <CardHeader className="py-3 px-4 flex flex-row items-center justify-end">
-          <div className="flex items-center gap-2">
-            <div className="min-w-[140px]">
-              <Select value={language} onValueChange={setLanguage}>
-                <SelectTrigger aria-label="Language">
-                  <SelectValue placeholder="Language" />
-                </SelectTrigger>
-                <SelectContent>
-                  {languages.map((l) => (
-                    <SelectItem key={l.key} value={l.key}>{l.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="min-w-[120px]">
-              <Select value={engine} onValueChange={setEngine}>
-                <SelectTrigger aria-label="Compiler">
-                  <SelectValue placeholder="Compiler" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="default">Default</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <Button size="icon" variant="ghost" aria-label="Copy compile code" title="Copy"
-              onClick={() => copyToClipboard(code)} disabled={!code || !!error || working}
-            >
-              {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
-            </Button>
+      <Card className={cn("relative h-full", className)}>
+        <CodeBlock
+          code={display}
+          language={lang}
+          className={cn("h-full pt-16", error && "text-red-500")}
+        />
+        <div className="absolute top-2 right-2 flex items-start gap-2">
+          <div className="min-w-[140px]">
+            <Select value={language} onValueChange={setLanguage}>
+              <SelectTrigger aria-label="Language">
+                <SelectValue placeholder="Language" />
+              </SelectTrigger>
+              <SelectContent>
+                {languages.map((l) => (
+                  <SelectItem key={l.key} value={l.key}>
+                    {l.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
-        </CardHeader>
-        <CardContent className="px-4 pb-4 flex-1 overflow-auto">
-          <div className="rounded-md bg-muted p-2 overflow-auto h-full">
-            {working ? (
-              <pre className="text-xs leading-relaxed opacity-70">Compiling…</pre>
-            ) : error ? (
-              <pre className="text-xs leading-relaxed text-red-500">{error}</pre>
-            ) : (
-              <pre className="text-xs leading-relaxed whitespace-pre-wrap break-words">{code}</pre>
-            )}
+          <div className="min-w-[120px]">
+            <Select value={engine} onValueChange={setEngine}>
+              <SelectTrigger aria-label="Compiler">
+                <SelectValue placeholder="Compiler" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="default">Default</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
-        </CardContent>
+          <Button
+            size="icon"
+            variant="ghost"
+            aria-label="Copy compile code"
+            title="Copy"
+            onClick={() => copyToClipboard(code)}
+            disabled={!code || !!error || working}
+          >
+            {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+          </Button>
+        </div>
       </Card>
     );
   }
@@ -229,6 +240,8 @@ export function CompilePanel({ graph, className, variant = "overlay" }: CompileP
     );
   }
 
+  const display = working ? "Compiling…" : error || code;
+  const lang = error ? "text" : getPrismLang(language);
   return (
     <div
       className={cn("fixed bottom-2 right-2 z-40 pointer-events-none", className)}
@@ -242,53 +255,51 @@ export function CompilePanel({ graph, className, variant = "overlay" }: CompileP
         onMouseDown={onHandleMouseDown}
         className="absolute left-[-4px] top-0 h-full w-2 cursor-col-resize bg-transparent pointer-events-auto"
       />
-      <Card className="pointer-events-auto">
-        <CardHeader className="py-3 px-4 flex flex-row items-center justify-between">
-          <CardTitle className="text-sm">Compile Output</CardTitle>
-          <div className="flex items-center gap-2">
-            <div className="min-w-[160px]">
-              <Select value={language} onValueChange={setLanguage}>
-                <SelectTrigger aria-label="Language">
-                  <SelectValue placeholder="Language" />
-                </SelectTrigger>
-                <SelectContent>
-                  {languages.map((l) => (
-                    <SelectItem key={l.key} value={l.key}>{l.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="min-w-[160px]">
-              <Select value={engine} onValueChange={setEngine}>
-                <SelectTrigger aria-label="Compiler">
-                  <SelectValue placeholder="Compiler" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="default">Default</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <Button size="icon" variant="ghost" aria-label="Copy compile code" title="Copy"
-              onClick={() => copyToClipboard(code)} disabled={!code || !!error || working}
-            >
-              {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
-            </Button>
-            <Button size="icon" variant="ghost" aria-label="Collapse" onClick={() => setCollapsed(true)}>
-              ▾
-            </Button>
+      <Card className="pointer-events-auto relative">
+        <CodeBlock
+          code={display}
+          language={lang}
+          className={cn("h-[50vh] pt-16", error && "text-red-500")}
+        />
+        <div className="absolute top-2 right-2 flex items-start gap-2">
+          <div className="min-w-[160px]">
+            <Select value={language} onValueChange={setLanguage}>
+              <SelectTrigger aria-label="Language">
+                <SelectValue placeholder="Language" />
+              </SelectTrigger>
+              <SelectContent>
+                {languages.map((l) => (
+                  <SelectItem key={l.key} value={l.key}>
+                    {l.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
-        </CardHeader>
-        <CardContent className="px-4 pb-4">
-          <div className="rounded-md bg-muted p-2 overflow-auto max-h-[50vh]">
-            {working ? (
-              <pre className="text-xs leading-relaxed opacity-70">Compiling…</pre>
-            ) : error ? (
-              <pre className="text-xs leading-relaxed text-red-500">{error}</pre>
-            ) : (
-              <pre className="text-xs leading-relaxed whitespace-pre-wrap break-words">{code}</pre>
-            )}
+          <div className="min-w-[160px]">
+            <Select value={engine} onValueChange={setEngine}>
+              <SelectTrigger aria-label="Compiler">
+                <SelectValue placeholder="Compiler" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="default">Default</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
-        </CardContent>
+          <Button
+            size="icon"
+            variant="ghost"
+            aria-label="Copy compile code"
+            title="Copy"
+            onClick={() => copyToClipboard(code)}
+            disabled={!code || !!error || working}
+          >
+            {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+          </Button>
+          <Button size="icon" variant="ghost" aria-label="Collapse" onClick={() => setCollapsed(true)}>
+            ▾
+          </Button>
+        </div>
       </Card>
     </div>
   );

--- a/src/components/GraphDataPanel.tsx
+++ b/src/components/GraphDataPanel.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Card } from "./ui/card";
 import { Button } from "./ui/button";
 import { cn } from "@/lib/utils";
 import { Check, Copy } from "lucide-react";
+import CodeBlock from "./CodeBlock";
 
 type GraphDataPanelProps = {
   data: unknown;
@@ -12,7 +13,11 @@ type GraphDataPanelProps = {
 
 function GraphDataPanelDocked({ data, className }: { data: unknown; className?: string }) {
   const pretty = useMemo(() => {
-    try { return JSON.stringify(data, null, 2); } catch { return String(data ?? ""); }
+    try {
+      return JSON.stringify(data, null, 2);
+    } catch {
+      return String(data ?? "");
+    }
   }, [data]);
   const [copied, setCopied] = useState(false);
   const copyToClipboard = useCallback(async () => {
@@ -38,20 +43,22 @@ function GraphDataPanelDocked({ data, className }: { data: unknown; className?: 
       // noop
     }
   }, [pretty]);
+
   return (
-    <Card className={cn("h-full flex flex-col", className)}>
-      <CardHeader className="py-3 px-4 flex flex-row items-center justify-end">
-        <div className="flex items-center gap-2">
-          <Button size="icon" variant="ghost" aria-label="Copy graph data" title="Copy" onClick={copyToClipboard} disabled={!pretty}>
-            {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
-          </Button>
-        </div>
-      </CardHeader>
-      <CardContent className="px-4 pb-4 flex-1 overflow-auto">
-        <div className="rounded-md bg-muted p-2 h-full overflow-auto">
-          <pre className="text-xs leading-relaxed whitespace-pre-wrap break-words">{pretty}</pre>
-        </div>
-      </CardContent>
+    <Card className={cn("relative h-full", className)}>
+      <CodeBlock code={pretty} language="json" className="h-full pt-10" />
+      <div className="absolute top-2 right-2 flex items-center gap-2">
+        <Button
+          size="icon"
+          variant="ghost"
+          aria-label="Copy graph data"
+          title="Copy"
+          onClick={copyToClipboard}
+          disabled={!pretty}
+        >
+          {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+        </Button>
+      </div>
     </Card>
   );
 }
@@ -155,25 +162,23 @@ function GraphDataPanelOverlay({ data, className }: { data: unknown; className?:
         onMouseDown={onHandleMouseDown}
         className="absolute left-[-4px] top-0 h-full w-2 cursor-col-resize bg-transparent pointer-events-auto"
       />
-      <Card className="pointer-events-auto">
-        <CardHeader className="py-3 px-4 flex flex-row items-center justify-between">
-          <CardTitle className="text-sm">Graph Data</CardTitle>
-          <div className="flex items-center gap-2">
-            <Button size="icon" variant="ghost" aria-label="Copy graph data" title="Copy" onClick={copyToClipboard} disabled={!pretty}>
-              {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
-            </Button>
-            <Button size="icon" variant="ghost" aria-label="Collapse" onClick={() => setCollapsed(true)}>
-              ▸
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent className="px-4 pb-4">
-          <div className="rounded-md bg-muted p-2 overflow-auto max-h-[60vh]">
-            <pre className="text-xs leading-relaxed whitespace-pre-wrap break-words">
-              {pretty}
-            </pre>
-          </div>
-        </CardContent>
+      <Card className="pointer-events-auto relative">
+        <CodeBlock code={pretty} language="json" className="h-[60vh] pt-10" />
+        <div className="absolute top-2 right-2 flex items-center gap-2">
+          <Button
+            size="icon"
+            variant="ghost"
+            aria-label="Copy graph data"
+            title="Copy"
+            onClick={copyToClipboard}
+            disabled={!pretty}
+          >
+            {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+          </Button>
+          <Button size="icon" variant="ghost" aria-label="Collapse" onClick={() => setCollapsed(true)}>
+            ▸
+          </Button>
+        </div>
       </Card>
     </div>
   );

--- a/tests/code_block_render.spec.tsx
+++ b/tests/code_block_render.spec.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+import { describe, it, expect, vi } from "vitest";
+import CodeBlock from "../src/components/CodeBlock";
+
+vi.mock("@/lib/utils", () => ({ cn: (...c: any[]) => c.filter(Boolean).join(" ") }));
+
+describe("CodeBlock", () => {
+  it("renders code and language class", () => {
+    const html = ReactDOMServer.renderToString(
+      <CodeBlock code="const x = 1;" language="js" />
+    );
+    expect(html).toContain("token keyword");
+    expect(html).toContain("language-js");
+  });
+});


### PR DESCRIPTION
## Summary
- fill compile and graph data panels with full-size code blocks and overlay controls
- add reusable CodeBlock component with prism-based syntax highlighting
- include prism-react-renderer dependency

## Testing
- `bun run lint`
- `bun run test`
- `bun run test:e2e` *(fails: Script not found "test:e2e")*
- `bun x tsc -p tsconfig.json --noEmit` *(fails: various TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bff259d0b4833294ec58cfdca61f5f