### PR TITLE
feat: display MaterialX node palette and graph XML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Generated test outputs
 tests/shaders/
+
+# cached MaterialX examples
+data/materialx/examples/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Purpose: Keep agents aligned on the absolute essentials needed to build, test, a
 - Source example graphs from MaterialX's `resources/Materials/Examples` directory and keep the parser in sync with typed nodes and graph outputs used there.
 - Mirror MaterialX's example directory structure so all upstream materials are available and grouped by their folders.
 - Avoid committing large or binary example assets (textures, images). Fetch MaterialX examples on demand and cache them locally so pushes stay light.
+- Ensure the MaterialX parser handles top-level shader nodes and multiple nodegraphs so example selections never load empty; cover both styles in tests.
 
 ## Quick Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,15 @@ Purpose: Keep agents aligned on the absolute essentials needed to build, test, a
 - Default compiler: default compile output language is `ThreeJS_GLSL`. Users can switch the compile output view, but preview remains bound to the ThreeJS GLSL compilation.
 - Centralized updates: define node update callbacks in `App` (e.g., `updateInputValue`, `updateNodeLabel`, `addNodeMeta`, `removeNodeMeta`) and attach them to `node.data`. Panels and renderers MUST use these callbacks instead of calling `rf.setNodes` directly.
 
+## Lessons Learned
+
+- Avoid leaving stub implementations in shared utilities. Provide safe fallbacks and unit tests so missing preview helpers cannot crash the app at runtime.
+- Keep server endpoints in sync with MaterialX as the canonical node source. Tests should cover node palette generation and MaterialX serialization so UI menus and graph data reflect the true graph.
+- Load example graphs from MaterialX XML files and ensure graph data updates whenever nodes or connections change.
+- Source example graphs from MaterialX's `resources/Materials/Examples` directory and keep the parser in sync with typed nodes and graph outputs used there.
+- Mirror MaterialX's example directory structure so all upstream materials are available and grouped by their folders.
+- Avoid committing large or binary example assets (textures, images). Fetch MaterialX examples on demand and cache them locally so pushes stay light.
+
 ## Quick Commands
 
 - Run unit tests: `bun run test`

--- a/data/materialx/examples-index.json
+++ b/data/materialx/examples-index.json
@@ -1,0 +1,64 @@
+{
+  "DisneyPrincipled": [
+    "disney_principled_carpaint",
+    "disney_principled_default",
+    "disney_principled_glass",
+    "disney_principled_gold",
+    "disney_principled_plastic"
+  ],
+  "GltfPbr": [
+    "gltf_pbr_boombox",
+    "gltf_pbr_carpaint",
+    "gltf_pbr_default",
+    "gltf_pbr_glass",
+    "gltf_pbr_gold",
+    "gltf_pbr_plastic"
+  ],
+  "OpenPbr": [
+    "open_pbr_aluminum_brushed",
+    "open_pbr_carpaint",
+    "open_pbr_default",
+    "open_pbr_glass",
+    "open_pbr_honey",
+    "open_pbr_ketchup",
+    "open_pbr_lightbulb",
+    "open_pbr_pearl",
+    "open_pbr_soapbubble",
+    "open_pbr_velvet"
+  ],
+  "SimpleHair": [
+    "simple_hair_default"
+  ],
+  "StandardSurface": [
+    "standard_surface_brass_tiled",
+    "standard_surface_brick_procedural",
+    "standard_surface_carpaint",
+    "standard_surface_chess_set",
+    "standard_surface_chrome",
+    "standard_surface_copper",
+    "standard_surface_default",
+    "standard_surface_glass",
+    "standard_surface_glass_tinted",
+    "standard_surface_gold",
+    "standard_surface_greysphere",
+    "standard_surface_greysphere_calibration",
+    "standard_surface_jade",
+    "standard_surface_look_brass_tiled",
+    "standard_surface_look_wood_tiled",
+    "standard_surface_marble_solid",
+    "standard_surface_metal_brushed",
+    "standard_surface_plastic",
+    "standard_surface_thin_film",
+    "standard_surface_velvet",
+    "standard_surface_wood_tiled"
+  ],
+  "UsdPreviewSurface": [
+    "usd_preview_surface_brass_tiled",
+    "usd_preview_surface_carpaint",
+    "usd_preview_surface_default",
+    "usd_preview_surface_glass",
+    "usd_preview_surface_gold",
+    "usd_preview_surface_plastic"
+  ]
+}
+

--- a/data/materialx/examples/cycle.mtlx
+++ b/data/materialx/examples/cycle.mtlx
@@ -1,4 +1,0 @@
-<?xml version="1.0"?>
-<materialx version="1.38" colorspace="lin_rec709" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <xi:include href="cycle.mtlx" />
-</materialx>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ import { fetchNodePalette, fetchNodeTemplate, type NodePalette, type NodePalette
 // Panels are now hosted inside a unified dock overlay
 import { useReactFlow } from "@xyflow/react";
 import { GraphNode } from "./components/GraphNode";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./components/ui/select";
+import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from "./components/ui/select";
 import { buildRFNodeFromTemplate } from "./core/ui/nodeFactory";
 import { isAbortError } from "./lib/errors";
 import { prepareVisibleNodes } from "./core/ui/visible";
@@ -43,7 +43,8 @@ export function App() {
   const idCounter = useRef(0);
   const [viewPath, setViewPath] = useState<string[]>([]); // breadcrumb of nested groups
   const [graphName, setGraphName] = useState<string>("UntitledGraph");
-  const [examples, setExamples] = useState<Array<{ key: string; label: string }>>([]);
+  const [exampleGroups, setExampleGroups] = useState<Array<{ key: string; label: string; examples: Array<{ key: string; label: string }> }>>([]);
+  const examples = useMemo(() => exampleGroups.flatMap((g) => g.examples), [exampleGroups]);
   const [selectedExample, setSelectedExample] = useState<string>("");
   const [menu, setMenu] = useState<{
     open: boolean;
@@ -190,12 +191,12 @@ export function App() {
           ...(parentId ? { parentId } : {}),
           ...nodeDefaults,
         } as any);
-        // children
         for (const child of n.nodes ?? []) {
           walk(child, idStr, depth + 1);
         }
       };
-      walk(graph, undefined, 0);
+      const roots = graph.type === "" ? graph.nodes ?? [] : [graph];
+      for (const r of roots) walk(r, undefined, 0);
 
       // Build edges from input pin refs ../<nodeId>/<pinId>
       const refRe = /^\.\.\/(\d+)\/(\d+)$/;
@@ -223,15 +224,18 @@ export function App() {
       const maxId = Math.max(...Object.keys(all).map((s) => Number(s)));
       idCounter.current = maxId;
 
-      // Choose default view: fragment_pass if present, else vertex_pass, else surface
-      const surfaceId = String(graph.id);
-      const fragmentPass = (graph.nodes ?? []).find((n) => n.type === "fragment_pass");
-      const vertexPass = (graph.nodes ?? []).find((n) => n.type === "vertex_pass");
-      const defaultPath = fragmentPass
-        ? [surfaceId, String(fragmentPass.id)]
-        : vertexPass
-          ? [surfaceId, String(vertexPass.id)]
-          : [surfaceId];
+      // Choose default view if graph has standard passes
+      let defaultPath: string[] = [];
+      if (graph.type === "surface") {
+        const surfaceId = String(graph.id);
+        const fragmentPass = (graph.nodes ?? []).find((n) => n.type === "fragment_pass");
+        const vertexPass = (graph.nodes ?? []).find((n) => n.type === "vertex_pass");
+        defaultPath = fragmentPass
+          ? [surfaceId, String(fragmentPass.id)]
+          : vertexPass
+            ? [surfaceId, String(vertexPass.id)]
+            : [surfaceId];
+      }
 
       // Attach update function to node data for safe edits from GraphNode
       setNodes(
@@ -247,7 +251,7 @@ export function App() {
         })) as any
       );
       setEdges(createdEdges);
-      setGraphName(ex.label ?? "UntitledGraph");
+      setGraphName(ex.label ?? graph.name ?? "UntitledGraph");
       setSelectedExample(ex.key);
       setViewPath(defaultPath);
     } catch (err) {
@@ -263,11 +267,12 @@ export function App() {
         const res = await fetch("/api/example-graphs", { signal: abort.signal });
         if (!res.ok) throw new Error(String(res.status));
         const data = await res.json();
-        const list: Array<{ key: string; label: string }> = Array.isArray(data.examples) ? data.examples : [];
-        setExamples(list);
-        if (list.length) {
+        const groups: Array<{ key: string; label: string; examples: Array<{ key: string; label: string }> }> = Array.isArray(data.groups) ? data.groups : [];
+        setExampleGroups(groups);
+        const flat = groups.flatMap((g) => g.examples);
+        if (flat.length) {
           // Default: load the first example
-          await loadExampleGraph(list[0]);
+          await loadExampleGraph(flat[0]);
         }
       } catch (err: any) {
         if (isAbortError(err)) return;
@@ -392,8 +397,15 @@ export function App() {
               <SelectValue placeholder="Select example graph" />
             </SelectTrigger>
             <SelectContent>
-              {examples.map((e) => (
-                <SelectItem key={e.key} value={e.key}>{e.label}</SelectItem>
+              {exampleGroups.map((g) => (
+                <SelectGroup key={g.key}>
+                  <SelectLabel>{g.label}</SelectLabel>
+                  {g.examples.map((e) => (
+                    <SelectItem key={e.key} value={e.key}>
+                      {e.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
               ))}
             </SelectContent>
           </Select>

--- a/src/components/GraphDataPanel.tsx
+++ b/src/components/GraphDataPanel.tsx
@@ -4,6 +4,7 @@ import { Button } from "./ui/button";
 import { cn } from "@/lib/utils";
 import { Check, Copy } from "lucide-react";
 import CodeBlock from "./CodeBlock";
+import { graphToMaterialX } from "@/core/io/materialx";
 
 type GraphDataPanelProps = {
   data: unknown;
@@ -14,7 +15,7 @@ type GraphDataPanelProps = {
 function GraphDataPanelDocked({ data, className }: { data: unknown; className?: string }) {
   const pretty = useMemo(() => {
     try {
-      return JSON.stringify(data, null, 2);
+      return graphToMaterialX(data);
     } catch {
       return String(data ?? "");
     }
@@ -46,7 +47,7 @@ function GraphDataPanelDocked({ data, className }: { data: unknown; className?: 
 
   return (
     <Card className={cn("relative h-full", className)}>
-      <CodeBlock code={pretty} language="json" className="h-full pt-10" />
+      <CodeBlock code={pretty} language="xml" className="h-full pt-10" />
       <div className="absolute top-2 right-2 flex items-center gap-2">
         <Button
           size="icon"
@@ -109,7 +110,7 @@ function GraphDataPanelOverlay({ data, className }: { data: unknown; className?:
 
   const pretty = useMemo(() => {
     try {
-      return JSON.stringify(data, null, 2);
+      return graphToMaterialX(data);
     } catch {
       return String(data ?? "");
     }
@@ -163,7 +164,7 @@ function GraphDataPanelOverlay({ data, className }: { data: unknown; className?:
         className="absolute left-[-4px] top-0 h-full w-2 cursor-col-resize bg-transparent pointer-events-auto"
       />
       <Card className="pointer-events-auto relative">
-        <CodeBlock code={pretty} language="json" className="h-[60vh] pt-10" />
+        <CodeBlock code={pretty} language="xml" className="h-[60vh] pt-10" />
         <div className="absolute top-2 right-2 flex items-center gap-2">
           <Button
             size="icon"

--- a/src/core/io/materialx.ts
+++ b/src/core/io/materialx.ts
@@ -53,83 +53,113 @@ export function graphToMaterialX(graph: any): string {
   return lines.join("\n");
 }
 
-// Parse a minimal MaterialX XML nodegraph back into canonical graph JSON.
-// Only supports the subset emitted by graphToMaterialX.
+// Parse a minimal MaterialX XML document back into canonical graph JSON.
+// Handles top-level shader nodes and multiple nodegraphs.
 export function materialxToGraph(xml: string) {
   const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "" });
   const doc = parser.parse(xml);
-  const ng = doc?.materialx?.nodegraph;
-  const graphName = ng?.name ?? "Graph";
-  const rawNodes: any[] = [];
-  if (ng) {
+  const root = doc?.materialx ?? {};
+
+  const nodeByName: Record<string, any> = {};
+  const outputByKey: Record<string, any> = {};
+  const nodes: any[] = [];
+  let id = 1;
+
+  const toInputs = (raw: any[]) =>
+    raw.map((inp: any, idx: number) => ({
+      id: idx,
+      name: inp.name,
+      type: inp.type,
+      value: inp.value,
+      __node: inp.node ?? inp.nodename,
+      __nodegraph: inp.nodegraph,
+      __output: inp.output,
+    }));
+
+  const addNode = (tag: string, obj: any) => {
+    const inputsRaw = obj.input ? (Array.isArray(obj.input) ? obj.input : [obj.input]) : [];
+    const outputsRaw = obj.output ? (Array.isArray(obj.output) ? obj.output : [obj.output]) : [];
+    if (outputsRaw.length === 0) outputsRaw.push({ name: "out", type: obj.type ?? tag });
+    const node = {
+      id: id++,
+      type: obj.type ?? tag,
+      name: obj.name ?? "",
+      meta: [],
+      nodes: [],
+      inputs: toInputs(inputsRaw),
+      outputs: outputsRaw.map((out: any, idx: number) => ({ id: idx, name: out.name, type: out.type })),
+    };
+    if (node.name) nodeByName[node.name] = node;
+    nodes.push(node);
+    return node;
+  };
+
+  const ngs = Array.isArray((root as any).nodegraph)
+    ? (root as any).nodegraph
+    : (root as any).nodegraph
+      ? [(root as any).nodegraph]
+      : [];
+  for (const ng of ngs) {
     for (const [key, val] of Object.entries(ng)) {
       if (key === "name" || key === "output" || key === "input") continue;
       const arr = Array.isArray(val) ? val : [val];
       for (const item of arr) {
         if (item && typeof item === "object" && "name" in item) {
-          rawNodes.push({ ...item, __tag: key });
+          addNode(item.type ?? key, item);
         }
       }
     }
+    const outs = ng.output ? (Array.isArray(ng.output) ? ng.output : [ng.output]) : [];
+    for (const out of outs) {
+      const src = nodeByName[out.nodename];
+      const srcOut = src?.outputs.find((o: any) => o.name === out.output) ?? src?.outputs?.[0];
+      const outNode = {
+        id: id++,
+        type: "output",
+        name: out.name,
+        meta: [],
+        nodes: [],
+        inputs: [{ id: 0, name: "in", type: out.type, value: src ? `../${src.id}/${srcOut?.id ?? 0}` : undefined }],
+        outputs: [],
+      };
+      if (src && srcOut) srcOut.value = `../${outNode.id}/0`;
+      nodes.push(outNode);
+      if (ng.name) outputByKey[`${ng.name}/${out.name}`] = outNode;
+    }
   }
-  const nodeByName: Record<string, any> = {};
-  const nodes: any[] = [];
-  let id = 1;
-  for (const rn of rawNodes) {
-    const inputsRaw = rn.input ? (Array.isArray(rn.input) ? rn.input : [rn.input]) : [];
-    const outputsRaw = rn.output ? (Array.isArray(rn.output) ? rn.output : [rn.output]) : [];
-    if (outputsRaw.length === 0) outputsRaw.push({ name: "out", type: rn.type ?? "" });
-    const node = {
-      id: id++,
-      type: rn.type ?? rn.__tag ?? "",
-      name: rn.name ?? "",
-      meta: [],
-      nodes: [],
-      inputs: inputsRaw.map((inp: any, idx: number) => ({
-        id: idx,
-        name: inp.name,
-        type: inp.type,
-        value: inp.value,
-        __node: inp.node ?? inp.nodename,
-        __output: inp.output,
-      })),
-      outputs: outputsRaw.map((out: any, idx: number) => ({ id: idx, name: out.name, type: out.type })),
-    };
-    nodeByName[node.name] = node;
-    nodes.push(node);
+
+  for (const [key, val] of Object.entries(root)) {
+    if (key === "nodegraph") continue;
+    const arr = Array.isArray(val) ? val : [val];
+    for (const item of arr) {
+      if (item && typeof item === "object" && "name" in item) {
+        addNode(item.type ?? key, item);
+      }
+    }
   }
-  const graphOutputs = ng?.output ? (Array.isArray(ng.output) ? ng.output : [ng.output]) : [];
-  for (const out of graphOutputs) {
-    const src = nodeByName[out.nodename];
-    const srcOut = src?.outputs.find((o: any) => o.name === out.output) ?? src?.outputs?.[0];
-    const outId = srcOut?.id ?? 0;
-    const node = {
-      id: id++,
-      type: "output",
-      name: out.name,
-      meta: [],
-      nodes: [],
-      inputs: [{ id: 0, name: "in", type: out.type, value: src ? `../${src.id}/${outId}` : undefined }],
-      outputs: [],
-    };
-    if (src && srcOut) srcOut.value = `../${node.id}/0`;
-    nodes.push(node);
-  }
+
   for (const n of nodes) {
     for (const pin of n.inputs) {
       if (pin.value) continue;
-      const src = nodeByName[pin.__node];
-      if (src) {
-        const out = src.outputs.find((o: any) => o.name === pin.__output) ?? src.outputs[0];
-        const outId = out?.id ?? 0;
-        pin.value = `../${src.id}/${outId}`;
-        if (out) {
-          out.value = `../${n.id}/${pin.id}`;
+      if (pin.__node) {
+        const src = nodeByName[pin.__node];
+        if (src) {
+          const out = src.outputs.find((o: any) => o.name === pin.__output) ?? src.outputs[0];
+          pin.value = `../${src.id}/${out?.id ?? 0}`;
+          if (out) out.value = `../${n.id}/${pin.id}`;
+        }
+      } else if (pin.__nodegraph) {
+        const outNode = outputByKey[`${pin.__nodegraph}/${pin.__output}`];
+        if (outNode) {
+          pin.value = `../${outNode.id}/0`;
         }
       }
       delete (pin as any).__node;
+      delete (pin as any).__nodegraph;
       delete (pin as any).__output;
     }
   }
+
+  const graphName = ngs[0]?.name ?? "Graph";
   return { type: "", name: graphName, meta: [], nodes, inputs: [], outputs: [] };
 }

--- a/src/core/io/materialx.ts
+++ b/src/core/io/materialx.ts
@@ -1,0 +1,135 @@
+import { XMLParser } from "fast-xml-parser";
+
+// Convert canonical graph JSON into a basic MaterialX XML string.
+// Only covers a minimal subset needed for previewing graph structure.
+export function graphToMaterialX(graph: any): string {
+  const lines: string[] = [];
+  const name = graph?.name ?? "Graph";
+  const gather: any[] = [];
+  const walk = (n: any) => {
+    if (!n || typeof n !== "object") return;
+    gather.push(n);
+    for (const c of Array.isArray(n.nodes) ? n.nodes : []) walk(c);
+  };
+  for (const n of Array.isArray(graph?.nodes) ? graph.nodes : []) walk(n);
+  lines.push('<?xml version="1.0"?>');
+  lines.push('<materialx version="1.39">');
+  lines.push(`  <nodegraph name="${name}">`);
+  const nodeById: Record<string, any> = {};
+  for (const n of gather) {
+    if (n && typeof n === "object" && ("id" in n)) nodeById[String(n.id)] = n;
+  }
+  for (const n of gather) {
+    if (!n || typeof n !== "object") continue;
+    const nodeName = n.name || `${n.type}_${n.id ?? ''}`;
+    lines.push(`    <node name="${nodeName}" type="${n.type}">`);
+    const inputs: any[] = Array.isArray(n.inputs) ? n.inputs : [];
+    for (const inp of inputs) {
+      let attrs = `name="${inp.name}" type="${inp.type}"`;
+      const val = inp.value;
+      if (typeof val === "string" && val.startsWith("../")) {
+        const [srcId, outId] = val.slice(3).split("/");
+        const src = nodeById[srcId];
+        if (src) {
+          const srcName = src.name || `${src.type}_${src.id ?? ''}`;
+          const out = (src.outputs || []).find((o: any) => String(o.id) === outId);
+          const outName = out ? out.name : `out${outId}`;
+          attrs += ` node="${srcName}" output="${outName}"`;
+        }
+      } else if (val !== undefined) {
+        const v = Array.isArray(val) ? val.join(',') : String(val);
+        attrs += ` value="${v}"`;
+      }
+      lines.push(`      <input ${attrs} />`);
+    }
+    const outputs: any[] = Array.isArray(n.outputs) ? n.outputs : [];
+    for (const out of outputs) {
+      lines.push(`      <output name="${out.name}" type="${out.type}" />`);
+    }
+    lines.push('    </node>');
+  }
+  lines.push('  </nodegraph>');
+  lines.push('</materialx>');
+  return lines.join("\n");
+}
+
+// Parse a minimal MaterialX XML nodegraph back into canonical graph JSON.
+// Only supports the subset emitted by graphToMaterialX.
+export function materialxToGraph(xml: string) {
+  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "" });
+  const doc = parser.parse(xml);
+  const ng = doc?.materialx?.nodegraph;
+  const graphName = ng?.name ?? "Graph";
+  const rawNodes: any[] = [];
+  if (ng) {
+    for (const [key, val] of Object.entries(ng)) {
+      if (key === "name" || key === "output" || key === "input") continue;
+      const arr = Array.isArray(val) ? val : [val];
+      for (const item of arr) {
+        if (item && typeof item === "object" && "name" in item) {
+          rawNodes.push({ ...item, __tag: key });
+        }
+      }
+    }
+  }
+  const nodeByName: Record<string, any> = {};
+  const nodes: any[] = [];
+  let id = 1;
+  for (const rn of rawNodes) {
+    const inputsRaw = rn.input ? (Array.isArray(rn.input) ? rn.input : [rn.input]) : [];
+    const outputsRaw = rn.output ? (Array.isArray(rn.output) ? rn.output : [rn.output]) : [];
+    if (outputsRaw.length === 0) outputsRaw.push({ name: "out", type: rn.type ?? "" });
+    const node = {
+      id: id++,
+      type: rn.type ?? rn.__tag ?? "",
+      name: rn.name ?? "",
+      meta: [],
+      nodes: [],
+      inputs: inputsRaw.map((inp: any, idx: number) => ({
+        id: idx,
+        name: inp.name,
+        type: inp.type,
+        value: inp.value,
+        __node: inp.node ?? inp.nodename,
+        __output: inp.output,
+      })),
+      outputs: outputsRaw.map((out: any, idx: number) => ({ id: idx, name: out.name, type: out.type })),
+    };
+    nodeByName[node.name] = node;
+    nodes.push(node);
+  }
+  const graphOutputs = ng?.output ? (Array.isArray(ng.output) ? ng.output : [ng.output]) : [];
+  for (const out of graphOutputs) {
+    const src = nodeByName[out.nodename];
+    const srcOut = src?.outputs.find((o: any) => o.name === out.output) ?? src?.outputs?.[0];
+    const outId = srcOut?.id ?? 0;
+    const node = {
+      id: id++,
+      type: "output",
+      name: out.name,
+      meta: [],
+      nodes: [],
+      inputs: [{ id: 0, name: "in", type: out.type, value: src ? `../${src.id}/${outId}` : undefined }],
+      outputs: [],
+    };
+    if (src && srcOut) srcOut.value = `../${node.id}/0`;
+    nodes.push(node);
+  }
+  for (const n of nodes) {
+    for (const pin of n.inputs) {
+      if (pin.value) continue;
+      const src = nodeByName[pin.__node];
+      if (src) {
+        const out = src.outputs.find((o: any) => o.name === pin.__output) ?? src.outputs[0];
+        const outId = out?.id ?? 0;
+        pin.value = `../${src.id}/${outId}`;
+        if (out) {
+          out.value = `../${n.id}/${pin.id}`;
+        }
+      }
+      delete (pin as any).__node;
+      delete (pin as any).__output;
+    }
+  }
+  return { type: "", name: graphName, meta: [], nodes, inputs: [], outputs: [] };
+}

--- a/src/core/preview/shaderUtils.ts
+++ b/src/core/preview/shaderUtils.ts
@@ -1,9 +1,75 @@
-export function parseUniformsAndSanitize(_fragmentSource: string): never {
-  throw new Error("Preview is disabled");
+/**
+ * Extract uniform declarations from a GLSL fragment shader and strip them from
+ * the source.
+ *
+ * Uniforms may optionally provide an initializer e.g.
+ * `uniform vec3 uColor = vec3(1.0, 0.0, 0.0);`
+ * The function returns a map of uniforms with their parsed default values and
+ * the fragment source without the uniform declarations so it can be supplied to
+ * `THREE.ShaderMaterial`.
+ */
+export function parseUniformsAndSanitize(fragmentSource: string): {
+  uniforms: Record<string, { type: string; value: any }>;
+  fragment: string;
+} {
+  const uniforms: Record<string, { type: string; value: any }> = {};
+  const uniformRe = /uniform\s+(\w+)\s+(\w+)\s*(=\s*([^;]+))?;/g;
+  let match: RegExpExecArray | null;
+  let sanitized = fragmentSource;
+  while ((match = uniformRe.exec(fragmentSource)) !== null) {
+    const [, type, name, , init] = match;
+    const value = init ? parseInitializer(type, init.trim()) : defaultValue(type);
+    uniforms[name] = { type, value };
+    sanitized = sanitized.replace(match[0], "");
+  }
+  return { uniforms, fragment: sanitized.trim() };
 }
+
+// Basic parser for GLSL initializers. Handles numeric and vec* constructors.
+function parseInitializer(type: string, init: string): any {
+  // Match vec* constructors e.g. vec3(1.0, 0.5, 0.0)
+  const vecMatch = init.match(/vec\d?\(([^)]*)\)/i);
+  if (vecMatch) {
+    return vecMatch[1]
+      .split(/[,\s]+/)
+      .filter(Boolean)
+      .map((v) => Number(v));
+  }
+  if (type === "bool") return init === "true";
+  const num = Number(init);
+  return Number.isNaN(num) ? 0 : num;
+}
+
+function defaultValue(type: string): any {
+  if (type === "bool") return false;
+  if (type.startsWith("vec")) {
+    const n = Number(type.slice(3));
+    return Array.from({ length: n }, () => 0);
+  }
+  return 0;
+}
+
+// Simple passthrough vertex shader used for preview rendering. It forwards the
+// vertex position and normal and computes clip space position.
 export function defaultVertexShader(): string {
-  throw new Error("Preview is disabled");
+  return /* glsl */ `
+    varying vec3 vPosition;
+    varying vec3 vNormal;
+    void main() {
+      vPosition = position;
+      vNormal = normalMatrix * normal;
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+  `;
 }
-export function toThreeUniforms(_parsed: any): Record<string, { value: any }> {
-  throw new Error("Preview is disabled");
+
+// Convert the parsed uniform map into the structure expected by Three.js
+// ShaderMaterial: { uniformName: { value: any } }
+export function toThreeUniforms(parsed: Record<string, { type: string; value: any }>): Record<string, { value: any }> {
+  const res: Record<string, { value: any }> = {};
+  for (const [key, info] of Object.entries(parsed ?? {})) {
+    res[key] = { value: info.value };
+  }
+  return res;
 }
+

--- a/src/core/schema/registry.ts
+++ b/src/core/schema/registry.ts
@@ -1,7 +1,7 @@
 import { promises as fs, readFileSync, readdirSync } from "fs";
 import path from "path";
 import { XMLParser } from "fast-xml-parser";
-import type { LanguagePack, NodeTemplate } from "./types";
+import type { LanguagePack, NodePalette, NodePaletteItem, NodeTemplate } from "./types";
 import { validateLanguagePack } from "./validators";
 
 const MATERIALX_ROOT = path.resolve(process.cwd(), "data", "materialx");
@@ -10,6 +10,7 @@ const LANG_ROOT = path.resolve(process.cwd(), "data", "languages");
 let templatesLoaded = false;
 const templateMap = new Map<string, NodeTemplate>();
 const dataTypes: string[] = [];
+const paletteItems: NodePaletteItem[] = [];
 
 function loadTemplatesSyncOnce() {
   if (templatesLoaded) return;
@@ -30,9 +31,12 @@ function loadTemplatesSyncOnce() {
       for (const nd of arr) {
         const inputs = Array.isArray(nd.input) ? nd.input : nd.input ? [nd.input] : [];
         const outputs = Array.isArray(nd.output) ? nd.output : nd.output ? [nd.output] : [];
+        const type = nd.name ?? nd.node ?? "";
+        const name = nd.node ?? nd.name ?? "";
+        const category = nd.nodegroup ?? "root";
         const tmpl: NodeTemplate = {
-          type: nd.name ?? nd.node ?? "",
-          name: nd.node ?? nd.name ?? "",
+          type,
+          name,
           meta: [],
           nodes: [],
           inputs: inputs.map((inp: any, i: number) => ({
@@ -47,7 +51,10 @@ function loadTemplatesSyncOnce() {
             type: out.type ?? "float",
           })),
         };
-        if (tmpl.type) templateMap.set(tmpl.type, tmpl);
+        if (type) {
+          templateMap.set(type, tmpl);
+          paletteItems.push({ type, name, path: type, category });
+        }
       }
     } catch (err) {
       console.warn("Failed to parse MaterialX file", file, err);
@@ -90,6 +97,22 @@ export function getNodeTemplate(type: string): NodeTemplate | undefined {
 export function getDataTypes(): string[] {
   loadTemplatesSyncOnce();
   return [...dataTypes];
+}
+
+export function getNodePalette(): NodePalette {
+  loadTemplatesSyncOnce();
+  const categories: Record<string, NodePaletteItem[]> = {};
+  for (const it of paletteItems) (categories[it.category] ??= []).push(it);
+  const orderedCategories = Object.keys(categories)
+    .sort((a, b) => a.localeCompare(b))
+    .map((name) => ({
+      name,
+      nodes: categories[name].sort((a, b) => a.name.localeCompare(b.name)),
+    }));
+  return {
+    categories: orderedCategories,
+    flat: [...paletteItems].sort((a, b) => a.name.localeCompare(b.name)),
+  };
 }
 
 export async function loadLanguage(nameOrPath: string): Promise<LanguagePack> {

--- a/src/server/examples.ts
+++ b/src/server/examples.ts
@@ -1,109 +1,56 @@
-import { NodeBuilder } from "../core/graph/node";
 import { promises as fs } from "fs";
 import path from "path";
+import { materialxToGraph } from "../core/io/materialx";
+
+const EXAMPLES_DIR = path.resolve(process.cwd(), "data", "materialx", "examples");
+const EXAMPLES_INDEX = path.resolve(process.cwd(), "data", "materialx", "examples-index.json");
+const MATERIALX_EXAMPLES_BASE =
+  "https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/59f98fe359728579e0e877a724c1483a6244bd9a/resources/Materials/Examples";
+
+async function readIndex(): Promise<Record<string, string[]>> {
+  const txt = await fs.readFile(EXAMPLES_INDEX, "utf8");
+  return JSON.parse(txt);
+}
+
+async function loadExample(name: string): Promise<string> {
+  const file = path.resolve(EXAMPLES_DIR, `${name}.mtlx`);
+  try {
+    if (!file.startsWith(EXAMPLES_DIR)) throw new Error("Invalid path");
+    return await fs.readFile(file, "utf8");
+  } catch {
+    const url = `${MATERIALX_EXAMPLES_BASE}/${name}.mtlx`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Failed to fetch example: ${res.status}`);
+    const xml = await res.text();
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, xml, "utf8");
+    return xml;
+  }
+}
+
+function toLabel(str: string): string {
+  return str.replace(/[-_]/g, " ").replace(/\b\w/g, (s) => s.toUpperCase());
+}
 
 export async function examplesHandler(req: Request): Promise<Response> {
   try {
     const url = new URL(req.url);
     const name = url.searchParams.get("name");
 
-    const registry: Array<{ key: string; label: string; build: () => any }> = [
-      {
-        key: "basic_color",
-        label: "Basic Color",
-        build: async () => {
-          const abs = path.resolve(process.cwd(), "examples", "basic_color.json");
-          const raw = await fs.readFile(abs, "utf8");
-          const json = JSON.parse(raw);
-          // The example file wraps the surface node in a root object with empty type
-          const surface = Array.isArray(json.nodes)
-            ? json.nodes.find((n: any) => n && typeof n === "object" && n.type === "surface")
-            : undefined;
-          return surface ?? json;
-        },
-      },
-      {
-        key: "addition",
-        label: "Addition (Color + Color)",
-        build: async () => {
-          const abs = path.resolve(process.cwd(), "examples", "addition_color_color.json");
-          const raw = await fs.readFile(abs, "utf8");
-          const json = JSON.parse(raw);
-          const surface = Array.isArray(json.nodes)
-            ? json.nodes.find((n: any) => n && typeof n === "object" && n.type === "surface")
-            : undefined;
-          return surface ?? json;
-        },
-      },
-      {
-        key: "float_to_roughness",
-        label: "Float → Roughness",
-        build: () => {
-          const surface = new NodeBuilder("surface");
-          const fragment_pass = surface.get_node_by_type("fragment_pass")!;
-          const fragment_output = surface.find_nested_node_by_type(fragment_pass, "fragment_output")!;
-          const flt = surface.create_node("float", fragment_pass);
-          fragment_output.meta!.push("shading_pbr");
-          surface.connect_nodes(flt, fragment_output, 0, 1);
-          return surface.to_dict();
-        },
-      },
-      {
-        key: "exposed_addition",
-        label: "Exposed Addition",
-        build: () => {
-          const surface = new NodeBuilder("surface");
-          const fragment_pass = surface.get_node_by_type("fragment_pass")!;
-          const fragment_output = surface.find_nested_node_by_type(fragment_pass, "fragment_output")!;
-          const red = surface.create_node("color", fragment_pass);
-          const green = surface.create_node("color", fragment_pass);
-          const red0 = Array.isArray(red.inputs) ? red.inputs[0] : undefined;
-          if (red0) red0.value = [1.0, 0.0, 0.0, 1.0];
-          const green0 = Array.isArray(green.inputs) ? green.inputs[0] : undefined;
-          if (green0) green0.value = [0.0, 1.0, 0.0, 1.0];
-          red.meta!.push("exposed");
-          green.meta!.push("exposed");
-          const add = surface.create_node("add", fragment_pass);
-          surface.connect_nodes(red, add, 0, 0);
-          surface.connect_nodes(green, add, 0, 1);
-          fragment_output.meta!.push("shading_pbr");
-          surface.connect_nodes(add, fragment_output, 0, 0);
-          return surface.to_dict();
-        },
-      },
-      {
-        key: "full_fragment",
-        label: "Full Fragment Outputs",
-        build: () => {
-          const surface = new NodeBuilder("surface");
-          const fragment_pass = surface.get_node_by_type("fragment_pass")!;
-          const fragment_output = surface.find_nested_node_by_type(fragment_pass, "fragment_output")!;
-          const albedo = surface.create_node("color", fragment_pass);
-          const rough = surface.create_node("float", fragment_pass);
-          const metallic = surface.create_node("float", fragment_pass);
-          const emission = surface.create_node("color", fragment_pass);
-          const normal = surface.create_node("color", fragment_pass);
-          const alpha = surface.create_node("float", fragment_pass);
-          surface.connect_nodes(albedo, fragment_output, 0, 0);
-          surface.connect_nodes(rough, fragment_output, 0, 1);
-          surface.connect_nodes(metallic, fragment_output, 0, 2);
-          surface.connect_nodes(emission, fragment_output, 0, 3);
-          surface.connect_nodes(normal, fragment_output, 0, 4);
-          fragment_output.meta!.push("shading_pbr");
-          surface.connect_nodes(alpha, fragment_output, 0, 5);
-          return surface.to_dict();
-        },
-      },
-    ];
-
     if (name) {
-      const found = registry.find((r) => r.key === name);
-      if (!found) return new Response("Not Found", { status: 404 });
-      const graph = await Promise.resolve(found.build());
-      return Response.json({ key: found.key, label: found.label, graph });
+      const xml = await loadExample(name);
+      const graph = materialxToGraph(xml);
+      return Response.json({ key: name, label: toLabel(path.basename(name)), graph });
     }
 
-    return Response.json({ examples: registry.map((r) => ({ key: r.key, label: r.label })) });
+    const index = await readIndex();
+    const groups = Object.entries(index).map(([dir, files]) => ({
+      key: dir,
+      label: toLabel(dir),
+      examples: files.map((f) => ({ key: `${dir}/${f}`, label: toLabel(f) })),
+    }));
+
+    return Response.json({ groups });
   } catch (err) {
     console.error("/api/example-graphs failed:", err);
     return new Response("Internal Server Error", { status: 500 });

--- a/src/server/nodes.ts
+++ b/src/server/nodes.ts
@@ -1,49 +1,9 @@
-import { promises as fs } from "fs";
-import path from "path";
+import { getNodePalette, getNodeTemplate } from "@/core/schema/registry";
 
 export async function nodesListHandler(): Promise<Response> {
   try {
-    const root = path.resolve(process.cwd(), "data", "nodes");
-
-    const items: Array<{ type: string; name: string; path: string; category: string }> = [];
-    async function walk(dir: string, prefix = ""): Promise<void> {
-      const entries = await fs.readdir(dir, { withFileTypes: true } as any);
-      for (const e of entries as any[]) {
-        const rel = path.join(prefix, e.name);
-        const abs = path.join(dir, e.name);
-        if (e.isDirectory()) {
-          await walk(abs, rel);
-        } else if (e.isFile() && e.name.endsWith(".json")) {
-          try {
-            const raw = await fs.readFile(abs, "utf8");
-            const json = JSON.parse(raw);
-            const type = String(json.type ?? "");
-            if (!type) continue;
-            const name = String(json.name ?? type);
-            const category = rel.split(path.sep)[0] ?? "root";
-            items.push({ type, name, path: rel, category });
-          } catch (err) {
-            console.warn("Failed parsing node template:", rel, err);
-          }
-        }
-      }
-    }
-    await walk(root);
-
-    const categories: Record<string, typeof items> = {};
-    for (const it of items) (categories[it.category] ??= []).push(it);
-
-    const orderedCategories = Object.keys(categories)
-      .sort((a, b) => a.localeCompare(b))
-      .map((name) => ({
-        name,
-        nodes: categories[name].sort((a, b) => a.name.localeCompare(b.name)),
-      }));
-
-    return Response.json({
-      categories: orderedCategories,
-      flat: items.sort((a, b) => a.name.localeCompare(b.name)),
-    });
+    const palette = getNodePalette();
+    return Response.json(palette);
   } catch (err) {
     console.error("/api/nodes failed:", err);
     return new Response("Internal Server Error", { status: 500 });
@@ -53,14 +13,11 @@ export async function nodesListHandler(): Promise<Response> {
 export async function nodeTemplateHandler(req: Request): Promise<Response> {
   try {
     const url = new URL(req.url);
-    const rel = url.searchParams.get("path");
-    if (!rel) return new Response("Missing path", { status: 400 });
-    const root = path.resolve(process.cwd(), "data", "nodes");
-    const abs = path.resolve(root, rel);
-    if (!abs.startsWith(root)) return new Response("Invalid path", { status: 400 });
-    const raw = await fs.readFile(abs, "utf8");
-    const json = JSON.parse(raw);
-    return Response.json(json);
+    const type = url.searchParams.get("path");
+    if (!type) return new Response("Missing path", { status: 400 });
+    const tmpl = getNodeTemplate(type);
+    if (!tmpl) return new Response("Not Found", { status: 404 });
+    return Response.json(tmpl);
   } catch (err) {
     console.error("/api/node-template failed:", err);
     return new Response("Internal Server Error", { status: 500 });

--- a/tests/materialx_examples.spec.ts
+++ b/tests/materialx_examples.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { materialxToGraph } from "../src/core/io/materialx";
+import { examplesHandler } from "../src/server/examples";
+
+const exampleRel = "StandardSurface/standard_surface_brass_tiled";
+const brassXML = `<?xml version="1.0"?>
+<materialx version="1.39" colorspace="lin_rec709" fileprefix="../../../Images/">
+  <nodegraph name="NG_brass1">
+    <tiledimage name="image_color" type="color3">
+      <input name="file" type="filename" value="brass_color.jpg" colorspace="srgb_texture" />
+      <input name="uvtiling" type="vector2" value="1.0, 1.0" />
+    </tiledimage>
+    <tiledimage name="image_roughness" type="float">
+      <input name="file" type="filename" value="brass_roughness.jpg" />
+      <input name="uvtiling" type="vector2" value="1.0, 1.0" />
+    </tiledimage>
+    <output name="out_color" type="color3" nodename="image_color" />
+    <output name="out_roughness" type="float" nodename="image_roughness" />
+  </nodegraph>
+  <standard_surface name="SR_brass1" type="surfaceshader">
+    <input name="base" type="float" value="1" />
+    <input name="base_color" type="color3" value="1, 1, 1" />
+    <input name="specular" type="float" value="0" />
+    <input name="specular_roughness" type="float" nodegraph="NG_brass1" output="out_roughness" />
+    <input name="metalness" type="float" value="1" />
+    <input name="coat" type="float" value="1" />
+    <input name="coat_color" type="color3" nodegraph="NG_brass1" output="out_color" />
+    <input name="coat_roughness" type="float" nodegraph="NG_brass1" output="out_roughness" />
+  </standard_surface>
+  <surfacematerial name="Tiled_Brass" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_brass1" />
+  </surfacematerial>
+</materialx>`;
+
+describe("MaterialX examples", () => {
+  it("parses standard_surface_brass_tiled.mtlx into graph", async () => {
+    const graph = materialxToGraph(brassXML);
+    expect(graph.nodes.length).toBe(4);
+    const image = graph.nodes.find((n: any) => n.name === "image_color");
+    expect(image).toBeTruthy();
+    const out = graph.nodes.find((n: any) => n.type === "output" && n.name === "out_color");
+    expect(out?.inputs[0]?.value).toBe(`../${image?.id}/0`);
+  });
+
+  it("serves MaterialX example via API and groups by directory", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(brassXML));
+    const spy = vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as any);
+
+    const listRes = await examplesHandler(new Request("http://localhost/api/example-graphs"));
+    const list = (await listRes.json()) as any;
+    const group = list.groups.find((g: any) => g.key === "StandardSurface");
+    expect(group).toBeTruthy();
+    const entry = group.examples.find((e: any) => e.key === exampleRel);
+    expect(entry).toBeTruthy();
+
+    const graphRes = await examplesHandler(new Request(`http://localhost/api/example-graphs?name=${encodeURIComponent(exampleRel)}`));
+    const data = (await graphRes.json()) as any;
+    expect(data.graph.nodes.length).toBe(4);
+
+    spy.mockRestore();
+  });
+});

--- a/tests/materialx_examples.spec.ts
+++ b/tests/materialx_examples.spec.ts
@@ -32,18 +32,43 @@ const brassXML = `<?xml version="1.0"?>
   </surfacematerial>
 </materialx>`;
 
+const defaultRel = "StandardSurface/standard_surface_default";
+const defaultXML = `<?xml version="1.0"?>
+<materialx version="1.39" colorspace="lin_rec709">
+  <standard_surface name="SR_default" type="surfaceshader">
+    <input name="base" type="float" value="1.0" />
+  </standard_surface>
+  <surfacematerial name="Default" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_default" />
+  </surfacematerial>
+</materialx>`;
+
 describe("MaterialX examples", () => {
   it("parses standard_surface_brass_tiled.mtlx into graph", async () => {
     const graph = materialxToGraph(brassXML);
-    expect(graph.nodes.length).toBe(4);
+    expect(graph.nodes.length).toBe(6);
     const image = graph.nodes.find((n: any) => n.name === "image_color");
-    expect(image).toBeTruthy();
+    const shader = graph.nodes.find((n: any) => n.name === "SR_brass1");
+    const mat = graph.nodes.find((n: any) => n.name === "Tiled_Brass");
+    expect(image && shader && mat).toBeTruthy();
     const out = graph.nodes.find((n: any) => n.type === "output" && n.name === "out_color");
     expect(out?.inputs[0]?.value).toBe(`../${image?.id}/0`);
+    const matIn = mat?.inputs[0];
+    expect(matIn?.value).toBe(`../${shader?.id}/0`);
+  });
+
+  it("parses standard_surface_default.mtlx without nodegraph", () => {
+    const graph = materialxToGraph(defaultXML);
+    expect(graph.nodes.length).toBe(2);
+    const surface = graph.nodes.find((n: any) => n.name === "SR_default");
+    const mat = graph.nodes.find((n: any) => n.name === "Default");
+    expect(mat?.inputs[0]?.value).toBe(`../${surface?.id}/0`);
   });
 
   it("serves MaterialX example via API and groups by directory", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(new Response(brassXML));
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve(new Response(url.includes("standard_surface_default") ? defaultXML : brassXML))
+    );
     const spy = vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as any);
 
     const listRes = await examplesHandler(new Request("http://localhost/api/example-graphs"));
@@ -53,9 +78,17 @@ describe("MaterialX examples", () => {
     const entry = group.examples.find((e: any) => e.key === exampleRel);
     expect(entry).toBeTruthy();
 
-    const graphRes = await examplesHandler(new Request(`http://localhost/api/example-graphs?name=${encodeURIComponent(exampleRel)}`));
+    const graphRes = await examplesHandler(
+      new Request(`http://localhost/api/example-graphs?name=${encodeURIComponent(exampleRel)}`)
+    );
     const data = (await graphRes.json()) as any;
-    expect(data.graph.nodes.length).toBe(4);
+    expect(data.graph.nodes.length).toBe(6);
+
+    const graphRes2 = await examplesHandler(
+      new Request(`http://localhost/api/example-graphs?name=${encodeURIComponent(defaultRel)}`)
+    );
+    const data2 = (await graphRes2.json()) as any;
+    expect(data2.graph.nodes.length).toBe(2);
 
     spy.mockRestore();
   });

--- a/tests/materialx_palette.spec.ts
+++ b/tests/materialx_palette.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { getNodePalette, getNodeTemplate } from "../src/core/schema/registry";
+import { graphToMaterialX } from "../src/core/io/materialx";
+
+describe("MaterialX integration", () => {
+  it("loads node palette from MaterialX stdlib", () => {
+    const palette = getNodePalette();
+    expect(palette.flat.length).toBeGreaterThan(0);
+    const add = palette.flat.find((n) => n.type === "ND_add_float");
+    expect(add).toBeTruthy();
+    expect(add?.category).toBe("math");
+    const tmpl = getNodeTemplate("ND_add_float");
+    expect(tmpl?.inputs?.length).toBeGreaterThan(0);
+  });
+
+  it("serializes graph to MaterialX XML", () => {
+    const graph = {
+      name: "Test",
+      nodes: [
+        {
+          id: 1,
+          type: "constant",
+          name: "const1",
+          inputs: [],
+          outputs: [{ id: 0, name: "out", type: "float" }],
+        },
+        {
+          id: 2,
+          type: "add",
+          name: "add1",
+          inputs: [{ id: 0, name: "a", type: "float", value: "../1/0" }],
+          outputs: [],
+        },
+      ],
+    };
+    const xml = graphToMaterialX(graph);
+    expect(xml).toContain('<nodegraph name="Test">');
+    expect(xml).toContain('<node name="const1" type="constant">');
+    expect(xml).toContain('<input name="a" type="float" node="const1" output="out" />');
+  });
+});

--- a/tests/preview_shader_utils.spec.ts
+++ b/tests/preview_shader_utils.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { parseUniformsAndSanitize, toThreeUniforms, defaultVertexShader } from "../src/core/preview/shaderUtils";
+
+describe("shaderUtils", () => {
+  it("parses uniforms and strips them from fragment", () => {
+    const src = `
+      uniform float uExposure = 1.2;
+      uniform vec3 uColor = vec3(1.0, 0.5, 0.0);
+      void main() { gl_FragColor = vec4(uColor, uExposure); }
+    `;
+    const res = parseUniformsAndSanitize(src);
+    expect(res.uniforms.uExposure.value).toBeCloseTo(1.2);
+    expect(res.uniforms.uColor.value).toEqual([1, 0.5, 0]);
+    expect(res.fragment).not.toMatch(/uniform/);
+  });
+
+  it("creates Three uniform map", () => {
+    const uniforms = toThreeUniforms({ uTime: { type: "float", value: 0.5 } });
+    expect(uniforms).toEqual({ uTime: { value: 0.5 } });
+  });
+
+  it("provides default vertex shader", () => {
+    const v = defaultVertexShader();
+    expect(v).toMatch(/gl_Position/);
+  });
+});


### PR DESCRIPTION
## Summary
- parse MaterialX XML into canonical graph objects, including typed nodes and nodegraph outputs
- serve official MaterialX `resources/Materials/Examples` graphs via API, now fetched on demand and cached to avoid committing binary assets
- test example parsing and palette generation with mocked MaterialX fetches and grouped listings
- mirror upstream MaterialX example directories via a JSON index and update AGENTS on remote fetching

## Testing
- `bun run lint`
- `bun run test`
- `bun dev` & `curl -I http://localhost:3000`
- `bun x tsc -p tsconfig.json --noEmit` *(type errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_68c081aa92e08332b9295d897ff81e4f