### PR TITLE
feat: show mini editors for unconnected pins

### DIFF
--- a/src/components/GraphNode.tsx
+++ b/src/components/GraphNode.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import ColorInput from "./inputs/ColorInput";
 import NumericVectorInput from "./inputs/NumericVectorInput";
 import { THEME } from "@/styles/theme";
+import { toNumericArray, fromNumericArray } from "@/core/ui/pinValues";
 
 type Pin = {
   id?: number;
@@ -93,13 +94,14 @@ export function GraphNode({ data, selected }: NodeProps<RFNode<GraphNodeData>>) 
             {inputs.map((pin, idx) => {
               const pid = typeof pin.id === "number" ? pin.id : idx;
               const connected = isConnected(pid);
-              const val = Array.isArray(pin.value) ? (pin.value as number[]) : undefined;
+              const val = toNumericArray(pin.value);
               const nodeType = data?.template?.type ?? data?.type ?? "";
-              const showColor = !connected && nodeType === "color" && pin.name === "in" && Array.isArray(val) && val.length >= 3;
+              const showEditor = !connected && typeof val !== "undefined";
+              const showColor = showEditor && nodeType === "color" && pin.name === "in" && val.length >= 3;
               return (
                 <div key={`in-${pid}`} className="relative flex items-center gap-2 justify-between min-h-[24px] w-full">
                   {/* Mini default-value editor docked to the left of the node, similar to Unity */}
-                  {!connected && Array.isArray(val) && (
+                  {showEditor && (
                     <>
                       <div
                         className="absolute z-[2] flex items-center gap-1 px-1 py-[2px] rounded-md border bg-background/90 backdrop-blur"
@@ -109,9 +111,18 @@ export function GraphNode({ data, selected }: NodeProps<RFNode<GraphNodeData>>) 
                         onWheel={(e) => e.stopPropagation()}
                       >
                         {showColor ? (
-                          <ColorInput value={val} disabled={false} size="mini" onCommit={(next) => updateInputValue(pid, next)} />
+                          <ColorInput
+                            value={val}
+                            disabled={false}
+                            size="mini"
+                            onCommit={(next) => updateInputValue(pid, fromNumericArray(next))}
+                          />
                         ) : (
-                          <NumericVectorInput value={val} size="mini" onChange={(next) => updateInputValue(pid, next)} />
+                          <NumericVectorInput
+                            value={val}
+                            size="mini"
+                            onChange={(next) => updateInputValue(pid, fromNumericArray(next))}
+                          />
                         )}
                       </div>
                       {/* Visual connector from editor → pin (purely decorative) across the 10px gap */}

--- a/src/components/GraphNode.tsx
+++ b/src/components/GraphNode.tsx
@@ -94,10 +94,14 @@ export function GraphNode({ data, selected }: NodeProps<RFNode<GraphNodeData>>) 
             {inputs.map((pin, idx) => {
               const pid = typeof pin.id === "number" ? pin.id : idx;
               const connected = isConnected(pid);
-              const val = toNumericArray(pin.value);
-              const nodeType = data?.template?.type ?? data?.type ?? "";
-              const showEditor = !connected && typeof val !== "undefined";
-              const showColor = showEditor && nodeType === "color" && pin.name === "in" && val.length >= 3;
+              const pinType = Array.isArray(pin.type) ? pin.type[0] : typeof pin.type === "string" ? pin.type : "";
+              const sizeMatch = typeof pinType === "string" ? pinType.match(/\d+/) : null;
+              const dim = sizeMatch ? Number.parseInt(sizeMatch[0]) : 1;
+              const isColor = typeof pinType === "string" && pinType.startsWith("color");
+              let val = toNumericArray(pin.value);
+              if (!val) val = new Array(dim).fill(0);
+              const showEditor = !connected;
+              const showColor = showEditor && isColor && val.length >= 3;
               return (
                 <div key={`in-${pid}`} className="relative flex items-center gap-2 justify-between min-h-[24px] w-full">
                   {/* Mini default-value editor docked to the left of the node, similar to Unity */}

--- a/src/core/ui/pinValues.ts
+++ b/src/core/ui/pinValues.ts
@@ -1,6 +1,13 @@
 export const toNumericArray = (val?: number[] | number | string): number[] | undefined => {
   if (Array.isArray(val)) return val as number[];
   if (typeof val === "number") return [val];
+  if (typeof val === "string") {
+    const nums = val
+      .split(/[\s,]+/)
+      .map((v) => Number.parseFloat(v))
+      .filter((n) => !Number.isNaN(n));
+    return nums.length ? nums : undefined;
+  }
   return undefined;
 };
 

--- a/src/core/ui/pinValues.ts
+++ b/src/core/ui/pinValues.ts
@@ -1,0 +1,9 @@
+export const toNumericArray = (val?: number[] | number | string): number[] | undefined => {
+  if (Array.isArray(val)) return val as number[];
+  if (typeof val === "number") return [val];
+  return undefined;
+};
+
+export const fromNumericArray = (arr: number[]): number | number[] => {
+  return arr.length === 1 ? arr[0] : arr;
+};

--- a/tests/pinValues.spec.ts
+++ b/tests/pinValues.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { toNumericArray, fromNumericArray } from "../src/core/ui/pinValues";
+
+describe("pinValues", () => {
+  it("converts number to array", () => {
+    expect(toNumericArray(3)).toEqual([3]);
+  });
+
+  it("passes through array", () => {
+    expect(toNumericArray([1, 2])).toEqual([1, 2]);
+  });
+
+  it("returns undefined for non-numeric", () => {
+    expect(toNumericArray("a" as any)).toBeUndefined();
+  });
+
+  it("reduces single-element arrays to number", () => {
+    expect(fromNumericArray([5])).toBe(5);
+  });
+
+  it("keeps multi-element arrays", () => {
+    expect(fromNumericArray([1, 2])).toEqual([1, 2]);
+  });
+});

--- a/tests/pinValues.spec.ts
+++ b/tests/pinValues.spec.ts
@@ -14,6 +14,11 @@ describe("pinValues", () => {
     expect(toNumericArray("a" as any)).toBeUndefined();
   });
 
+  it("parses numeric strings", () => {
+    expect(toNumericArray("1,2,3")).toEqual([1, 2, 3]);
+    expect(toNumericArray("4 5 6")).toEqual([4, 5, 6]);
+  });
+
   it("reduces single-element arrays to number", () => {
     expect(fromNumericArray([5])).toBe(5);
   });


### PR DESCRIPTION
## Summary
- show small input editors for unconnected pins, including scalar defaults
- normalize pin values between scalar and array forms
- test pin value helpers

## Testing
- `bun run lint`
- `bun run test`
- `bun dev` & `curl -I http://localhost:3000/`


------
https://chatgpt.com/codex/tasks/task_e_68c09cd06bd0833291f71f0715b3e1c6