### PR TITLE
Fix ThreeJS preview projection uniform and add shader error e2e coverage

### DIFF
--- a/e2e/shader-compilation.spec.ts
+++ b/e2e/shader-compilation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page, Response } from "@playwright/test";
+import { test, expect, Page, Response, ConsoleMessage } from "@playwright/test";
 
 async function gotoApp(page: Page) {
   await page.addInitScript(() => {
@@ -43,14 +43,94 @@ async function ensureCompilePanelOpen(page: Page) {
   await expect(page.getByLabel("Language")).toBeVisible({ timeout: 10000 });
 }
 
-function waitForCompile(page: Page, expectedLanguage?: string): Promise<Response> {
+type CompileWaitOptions = {
+  language?: string;
+  engine?: string;
+};
+
+function waitForCompile(page: Page, options?: CompileWaitOptions): Promise<Response> {
   return page.waitForResponse((response) => {
     if (!response.url().includes("/api/compile")) return false;
     if (response.request().method() !== "POST") return false;
-    if (!expectedLanguage) return true;
+    if (!options) return true;
     const body = response.request().postData();
-    return typeof body === "string" && body.includes(`"language":"${expectedLanguage}"`);
+    if (typeof body !== "string") return false;
+    if (options.language && !body.includes(`"language":"${options.language}"`)) return false;
+    if (options.engine && !body.includes(`"engine":"${options.engine}"`)) return false;
+    return true;
   });
+}
+
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function openExample(page: Page, path: string[]) {
+  if (!path.length) return;
+  const trigger = page.getByRole("menuitem", { name: /^Examples$/i }).first();
+  await trigger.hover();
+  await trigger.click();
+  const rootMenu = page.getByRole("menu", { name: /^Examples$/i }).first();
+  await expect(rootMenu).toBeVisible({ timeout: 5000 });
+  let currentMenu = rootMenu;
+  for (let i = 0; i < path.length; i++) {
+    const segment = path[i];
+    const matcher = new RegExp(`^${escapeRegex(segment)}$`, "i");
+    const item = currentMenu.getByRole("menuitem", { name: matcher }).first();
+    const beforeCount = await page.getByRole("menu").count();
+    await item.hover();
+    const isLast = i === path.length - 1;
+    if (isLast) {
+      await item.click();
+      break;
+    }
+    await page.waitForFunction(
+      (prev) => {
+        const menus = Array.from(document.querySelectorAll('[role="menu"]'));
+        return menus.length > prev;
+      },
+      beforeCount,
+      { timeout: 2000 }
+    );
+    const menus = page.getByRole("menu");
+    const newCount = await menus.count();
+    currentMenu = menus.nth(newCount - 1);
+  }
+  await page.keyboard.press("Escape");
+}
+
+function capturePreviewConsoleErrors(page: Page): () => string[] {
+  const errors = new Set<string>();
+  const consoleHandler = (msg: ConsoleMessage) => {
+    if (msg.type() !== "error") return;
+    const text = msg.text();
+    if (/THREE\.WebGLProgram: Shader Error/i.test(text)) {
+      errors.add(text.trim());
+      return;
+    }
+    if (/Fragment shader is not compiled/i.test(text)) {
+      errors.add(text.trim());
+      return;
+    }
+    if (/\[preview-render-error\]/i.test(text)) {
+      errors.add(text.trim());
+    }
+  };
+  const pageErrorHandler = (err: Error | any) => {
+    const message = err?.message ? `[pageerror] ${err.message}` : `[pageerror] ${String(err)}`;
+    errors.add(message.trim());
+  };
+  page.on("console", consoleHandler);
+  page.on("pageerror", pageErrorHandler);
+  let stopped = false;
+  return () => {
+    if (!stopped) {
+      page.off("console", consoleHandler);
+      page.off("pageerror", pageErrorHandler);
+      stopped = true;
+    }
+    return Array.from(errors);
+  };
 }
 
 test.describe("Shader Compilation", () => {
@@ -60,7 +140,7 @@ test.describe("Shader Compilation", () => {
 
     await expect(page.getByLabel("Language")).toContainText(/ThreeJS/i);
 
-    const godotCompile = waitForCompile(page, "Godot");
+    const godotCompile = waitForCompile(page, { language: "Godot" });
     await page.getByLabel("Language").click();
     await page.getByRole("option", { name: "Godot" }).click();
 
@@ -73,7 +153,7 @@ test.describe("Shader Compilation", () => {
     expect(godotBody).toContain('"language":"Godot"');
     await expect(page.getByLabel("Language")).toContainText(/Godot/i);
 
-    const glslCompile = waitForCompile(page, "ThreeJS_GLSL");
+    const glslCompile = waitForCompile(page, { language: "ThreeJS_GLSL" });
     await page.getByLabel("Language").click();
     await page.getByRole("option", { name: "ThreeJS GLSL" }).click();
 
@@ -96,5 +176,22 @@ test.describe("Shader Compilation", () => {
     await toggleViewMenuItem(page, /^Preview/i);
     const previewCanvas = page.locator('canvas[data-engine^="three.js"]').first();
     await expect(previewCanvas).toBeVisible();
+  });
+
+  test("DistanceFade example preview compiles without WebGL errors", async ({ page }) => {
+    const stopCapture = capturePreviewConsoleErrors(page);
+    await gotoApp(page);
+    await toggleViewMenuItem(page, /^Preview/i);
+    const previewCanvas = page.locator('canvas[data-engine^="three.js"]').first();
+    await expect(previewCanvas).toBeVisible();
+
+    const previewCompile = waitForCompile(page, { language: "ThreeJS_GLSL", engine: "preview" });
+    await openExample(page, ["BenCloward Tutorials", "09 InputVectors", "DistanceFade"]);
+    const response = await previewCompile;
+    expect(response.ok()).toBeTruthy();
+    await page.waitForTimeout(500);
+
+    const errors = stopCapture();
+    expect(errors, `ThreeJS preview errors detected:\n${errors.join("\n\n")}`).toHaveLength(0);
   });
 });

--- a/src/core/preview/shaderUtils.ts
+++ b/src/core/preview/shaderUtils.ts
@@ -25,6 +25,8 @@ export type ParsedShader = {
 const UNIFORM_INIT_RE = /(^|\n)\s*uniform\s+(?<type>float|vec2|vec3|vec4)\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?<init>[^;]+);/g;
 const VERTEX_BEGIN_TOKEN = "// __VERTEX_PASS_BEGIN__";
 const VERTEX_END_TOKEN = "// __VERTEX_PASS_END__";
+const PROJECTION_MATRIX_UNIFORM_RE = /uniform\s+mat[234]\s+projectionMatrix\b/;
+const PROJECTION_MATRIX_REF_RE = /\bprojectionMatrix\b/;
 
 function parseInitToValue(type: string, init: string): number | number[] {
   const t = type.trim();
@@ -116,6 +118,16 @@ export function parseUniformsAndSanitize(fragmentSource: string): ParsedShader {
     if (varyingSeen.has(canonical)) continue;
     varyingSeen.add(canonical);
     varyings.push(canonical);
+  }
+  const needsProjectionUniform = PROJECTION_MATRIX_REF_RE.test(out) && !PROJECTION_MATRIX_UNIFORM_RE.test(out);
+  if (needsProjectionUniform) {
+    const precisionMatch = out.match(/precision\s+(highp|mediump|lowp)\s+float\s*;/);
+    if (precisionMatch) {
+      const insertIndex = precisionMatch.index! + precisionMatch[0].length;
+      out = `${out.slice(0, insertIndex)}\nuniform mat4 projectionMatrix;${out.slice(insertIndex)}`;
+    } else {
+      out = `uniform mat4 projectionMatrix;\n${out}`;
+    }
   }
   return { fragment: out, uniforms, samplers, varyings };
 }

--- a/tests/preview_shader_utils.spec.ts
+++ b/tests/preview_shader_utils.spec.ts
@@ -31,6 +31,22 @@ void main(){ gl_FragColor = vec4(u_color, 1.0); }
   expect(by.get("u_tint")?.value).toEqual([0.1, 0.2, 0.3, 0.4]);
   expect(parsed.varyings).toEqual([]);
 });
+
+  it("injects projectionMatrix uniform when referenced", () => {
+    const src = `precision highp float;\nvoid main(){ vec4 clip = projectionMatrix * vec4(1.0); gl_FragColor = clip; }`;
+    const parsed = parseUniformsAndSanitize(src);
+    expect(parsed.fragment).toMatch(/uniform\s+mat4\s+projectionMatrix\s*;/);
+    const firstIndex = parsed.fragment.indexOf("uniform mat4 projectionMatrix;");
+    const precisionIndex = parsed.fragment.indexOf("precision highp float;");
+    expect(firstIndex).toBeGreaterThan(precisionIndex);
+  });
+
+  it("does not duplicate projectionMatrix uniform if already declared", () => {
+    const src = `precision highp float;\nuniform mat4 projectionMatrix;\nvoid main(){ gl_FragColor = projectionMatrix * vec4(1.0); }`;
+    const parsed = parseUniformsAndSanitize(src);
+    const matches = parsed.fragment.match(/uniform\s+mat4\s+projectionMatrix/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
 });
 
 it("extracts vertex chunk markers and rebuilds vertex shader", () => {


### PR DESCRIPTION
## Summary
- ensure the ThreeJS preview fragment shader injects a projectionMatrix uniform when required
- expand preview shader utilities coverage for the projection uniform fallback
- harden shader compilation e2e tests to detect ThreeJS preview errors and load the DistanceFade example

## Testing
- bun run lint
- bun x tsc -p tsconfig.json --noEmit
- bun run test
- bun run build
- bun run test:e2e
- bun run validate:shaders

------
https://chatgpt.com/codex/tasks/task_e_68e3eff3504083329ec405a91d75055e