### PR TITLE
Restore doc navigation entries via anchored sections

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,3 +13,21 @@ Some artists or tech artists prefer to use node-based solutions to create shader
 - Some engines are not even supported by any node-based editor.
 
 OpenShaderGraph is an engine‑agnostic node graph for authoring shaders. It focuses on canonical data and template‑driven compilation rather than editor‑specific logic, so you can build once and export to multiple targets.
+
+## Features {#features}
+
+Detailed feature documentation is still in progress. For now, explore the Getting Started guide to see the core surface area.
+
+## Tutorials {#tutorials}
+
+### Basic Color {#tutorial-basic-color}
+
+Step-by-step tutorials are coming soon. This entry will cover building a basic color node chain once the material is ready.
+
+### Addition (Color + Color) {#tutorial-addition-color-color}
+
+Future tutorials will show how to blend colors and reuse nodes effectively. Check back later for the complete walkthrough.
+
+## Contributing {#contributing}
+
+Contributor documentation is being prepared. Until then, review the Developers guide for project conventions and setup.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,14 +33,14 @@ theme:
 
 nav:
   - Overview: index.md
-  - Getting Started: getting-started.md
-  - Features: features.md
+  - Features: index.md#features
   - Tutorials:
-      - Overview: tutorials.md
-      - Basic Color: tutorials/basic-color.md
-      - Addition (Color + Color): tutorials/add-color-color.md
+      - Overview: index.md#tutorials
+      - Basic Color: index.md#tutorial-basic-color
+      - Addition (Color + Color): index.md#tutorial-addition-color-color
+  - Contributing: index.md#contributing
+  - Getting Started: getting-started.md
   - Developers: developers.md
-  - Contributing: contributing.md
 
 plugins:
   - search


### PR DESCRIPTION
## Summary
- add anchored sections to the overview page so planned docs can live on a single page without missing files
- point the MkDocs navigation entries at those anchors to keep the sidebar options visible without build warnings

## Testing
- bun run gates

------
https://chatgpt.com/codex/tasks/task_e_68e4c6b724bc8332876f741c3f2688f9