### PR TITLE
style: emphasize breadcrumb container

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2818,9 +2818,10 @@ export function App() {
           </MenubarMenu>
         </Menubar>
       </div>
-      <div className="flex-1 flex items-center">
-        <Breadcrumb>
-          <BreadcrumbList>
+      <div className="flex-1">
+        <div className="flex items-center rounded-md border border-border/40 bg-muted/40 px-3 py-1.5 shadow-sm">
+          <Breadcrumb className="w-full">
+            <BreadcrumbList className="text-xs">
             <BreadcrumbItem>
               <BreadcrumbLink asChild>
                 <button onClick={() => setViewPath([])} className="hover:underline text-xs">{graphName}</button>
@@ -2846,8 +2847,9 @@ export function App() {
                 </Fragment>
               );
             })}
-          </BreadcrumbList>
-        </Breadcrumb>
+            </BreadcrumbList>
+          </Breadcrumb>
+        </div>
       </div>
       <div className="flex items-center gap-2">
         <Button


### PR DESCRIPTION
## Summary
- wrap the breadcrumb navigation in a muted, rounded container to separate it from the menu bar
- ensure breadcrumb list typography stays compact within the new container styling

## Testing
- bun install --frozen-lockfile
- bun run lint
- bun x tsc -p tsconfig.json --noEmit
- bun run test
- bun run test:coverage
- bun run build
- bun run test:e2e
- bun run validate:shaders

------
https://chatgpt.com/codex/tasks/task_e_68e588df5728833299d6db49beee77db