### PR TITLE
feat: add about section to settings page

### DIFF
--- a/src/ui/settings/SettingsPage.tsx
+++ b/src/ui/settings/SettingsPage.tsx
@@ -99,14 +99,10 @@ export function SettingsPage({
           <CardHeader>
             <CardTitle>About Me</CardTitle>
             <CardDescription>
-              Minimal tools, thoughtful shaders, and a curiosity for beautiful lighting.
+              I&apos;m Omid Saadat - Trying to make bridges.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3 text-sm text-muted-foreground">
-            <p>
-              I&apos;m Omid Saadat — exploring real-time rendering and sharing the journey. Connect
-              with me:
-            </p>
             <ul className="space-y-2">
               <li>
                 <a

--- a/src/ui/settings/SettingsPage.tsx
+++ b/src/ui/settings/SettingsPage.tsx
@@ -94,6 +94,53 @@ export function SettingsPage({
         </Card>
 
         <HotkeySettingsCard hotkeys={quickHotkeys} onChange={onQuickHotkeysChange} palette={palette} />
+
+        <Card>
+          <CardHeader>
+            <CardTitle>About Me</CardTitle>
+            <CardDescription>
+              Minimal tools, thoughtful shaders, and a curiosity for beautiful lighting.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <p>
+              I&apos;m Omid Saadat — exploring real-time rendering and sharing the journey. Connect
+              with me:
+            </p>
+            <ul className="space-y-2">
+              <li>
+                <a
+                  className="transition-colors hover:text-foreground"
+                  href="https://omid-saadat.com"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  omid-saadat.com
+                </a>
+              </li>
+              <li>
+                <a
+                  className="transition-colors hover:text-foreground"
+                  href="https://x.com/omid3098"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  @omid3098 on X
+                </a>
+              </li>
+              <li>
+                <a
+                  className="transition-colors hover:text-foreground"
+                  href="https://github.com/omid3098"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  @omid3098 on GitHub
+                </a>
+              </li>
+            </ul>
+          </CardContent>
+        </Card>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a minimalist About Me card to the Settings page with links to Omid Saadat's site, X, and GitHub profiles

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68e58ec408308332ac33f415e7ad8831