### PR TITLE
feat: integrate ambientcg asset library

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "bun-plugin-tailwind": "^0.0.14",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "fflate": "^0.8.1",
         "lucide-react": "^0.475.0",
         "prism-react-renderer": "^2.4.1",
         "react": "^19",
@@ -698,6 +699,8 @@
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
 
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@radix-ui/react-select": "^2.1.6",
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-tabs": "^1.1.13",
+        "@tanstack/react-virtual": "^3.10.9",
         "@xyflow/react": "^12.8.4",
         "bun-plugin-tailwind": "^0.0.14",
         "class-variance-authority": "^0.7.1",
@@ -347,6 +348,10 @@
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@2.3.0", "", {}, "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="],
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.12", "", { "dependencies": { "@tanstack/virtual-core": "3.13.12" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.13.12", "", {}, "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@tanstack/react-virtual": "^3.10.9",
     "@xyflow/react": "^12.8.4",
     "bun-plugin-tailwind": "^0.0.14",
     "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "bun-plugin-tailwind": "^0.0.14",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "fflate": "^0.8.1",
     "lucide-react": "^0.475.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^19",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,13 +97,13 @@ const initialNodes: Node[] = [];
 const initialEdges: Edge[] = [];
 
 const DEFAULT_ASSET_LIBRARIES: AssetLibrariesSettings = {
-  ambientcg: { enabled: false },
+  ambientcg: { enabled: true },
 };
 
 function normalizeAssetLibraries(value?: AssetLibrariesSettings | null): AssetLibrariesSettings {
   return {
     ambientcg: {
-      enabled: value?.ambientcg?.enabled === true,
+      enabled: value?.ambientcg?.enabled !== false,
     },
   };
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ import {
   type NodeUpdaterApi,
 } from "./core/ui/nodeUpdaters";
 import { GraphStateProvider } from "./core/ui/GraphStateContext";
-import { SettingsProvider, type CurveMode, type ThemeName } from "./ui/state/SettingsContext";
+import { SettingsProvider, type CurveMode, type ThemeName, type AssetLibrariesSettings } from "./ui/state/SettingsContext";
 import { isAbortError } from "./lib/errors";
 import { prepareVisibleNodes } from "./core/ui/visible";
 import { buildGraphData } from "./core/ui/graphData";
@@ -95,6 +95,18 @@ const nodeDefaults = {
 const initialNodes: Node[] = [];
 
 const initialEdges: Edge[] = [];
+
+const DEFAULT_ASSET_LIBRARIES: AssetLibrariesSettings = {
+  ambientcg: { enabled: false },
+};
+
+function normalizeAssetLibraries(value?: AssetLibrariesSettings | null): AssetLibrariesSettings {
+  return {
+    ambientcg: {
+      enabled: value?.ambientcg?.enabled === true,
+    },
+  };
+}
 
 const ALIGNMENT_LABELS: Record<AlignmentKind, string> = {
   left: "Align Left",
@@ -200,6 +212,7 @@ export function App() {
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
   const [palette, setPalette] = useState<NodePalette | null>(null);
   const [quickNodeHotkeys, setQuickNodeHotkeysState] = useState<QuickNodeHotkey[]>(DEFAULT_QUICK_NODE_HOTKEYS);
+  const [assetLibraries, setAssetLibrariesState] = useState<AssetLibrariesSettings>(DEFAULT_ASSET_LIBRARIES);
   const idCounter = useRef(0);
   const [viewPath, setViewPath] = useState<string[]>([]); // breadcrumb of nested groups
   const viewPathRef = useRef(viewPath);
@@ -300,6 +313,22 @@ export function App() {
     void persistSet("ui.quickNodeHotkeys", quickNodeHotkeys);
   }, [quickNodeHotkeys]);
 
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const stored = await persistGet<AssetLibrariesSettings>("ui.assetLibraries");
+      if (cancelled || !stored) return;
+      setAssetLibrariesState(normalizeAssetLibraries(stored));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    void persistSet("ui.assetLibraries", assetLibraries);
+  }, [assetLibraries]);
+
   const setQuickNodeHotkeys = useCallback(
     (next: QuickNodeHotkey[] | ((prev: QuickNodeHotkey[]) => QuickNodeHotkey[])) => {
       setQuickNodeHotkeysState((prev) => {
@@ -334,6 +363,20 @@ export function App() {
   const setCurveMode = useCallback((next: CurveMode) => {
     setCurveModeState(next);
   }, [setCurveModeState]);
+
+  const setAssetLibraries = useCallback(
+    (next: AssetLibrariesSettings | ((prev: AssetLibrariesSettings) => AssetLibrariesSettings)) => {
+      setAssetLibrariesState((prev) => {
+        const updated = typeof next === "function" ? (next as (prev: AssetLibrariesSettings) => AssetLibrariesSettings)(prev) : next;
+        const normalized = normalizeAssetLibraries(updated);
+        if (normalized.ambientcg.enabled === prev.ambientcg.enabled) {
+          return prev;
+        }
+        return normalized;
+      });
+    },
+    []
+  );
 
 
   const renderSidebar = useCallback(
@@ -539,6 +582,14 @@ export function App() {
 
   const quickHotkeyMap = useMemo(() => buildQuickHotkeyMap(quickNodeHotkeys), [quickNodeHotkeys]);
 
+  const enabledLibraryProviders = useMemo(() => {
+    const list: string[] = [];
+    if (assetLibraries.ambientcg.enabled) {
+      list.push("ambientcg");
+    }
+    return list;
+  }, [assetLibraries]);
+
   const handleQuickHotkeysChange = useCallback(
     (next: QuickNodeHotkey[]) => {
       setQuickNodeHotkeys(next);
@@ -554,8 +605,10 @@ export function App() {
       setCurveMode,
       quickHotkeys: quickHotkeysForSettings,
       setQuickHotkeys: setQuickNodeHotkeys,
+      assetLibraries,
+      setAssetLibraries,
     }),
-    [curveMode, quickHotkeysForSettings, setCurveMode, setQuickNodeHotkeys, setTheme, theme]
+    [assetLibraries, curveMode, quickHotkeysForSettings, setAssetLibraries, setCurveMode, setQuickNodeHotkeys, setTheme, theme]
   );
 
   const templateCacheRef = useRef<TemplateCache | null>(null);
@@ -1480,7 +1533,7 @@ export function App() {
         ? (rootCandidate.nodes.find((n: any) => n?.type === "surface") ?? rootCandidate.nodes[0])
         : (inflatedGraph as any);
 
-      const assetRegistry = await loadAssetRegistry();
+      const assetRegistry = await loadAssetRegistry({ providers: enabledLibraryProviders });
 
       const buildResult = buildReactFlowGraph({
         root: rootGraph as any,
@@ -1505,7 +1558,7 @@ export function App() {
       fitAfterLoadRef.current = true;
     },
     // ensureColoredEdges is not referenced inside; remove to satisfy exhaustive-deps
-    [nodeUpdaterApi, resetHistory, setEdges, setGraphName, setNodes, setViewPath, paletteByType]
+    [enabledLibraryProviders, nodeUpdaterApi, resetHistory, setEdges, setGraphName, setNodes, setViewPath, paletteByType]
   );
 
   const loadExampleGraph = useCallback(async (ex: { key: string; label: string }) => {
@@ -2991,6 +3044,8 @@ export function App() {
               quickHotkeys={quickHotkeysForSettings}
               onQuickHotkeysChange={handleQuickHotkeysChange}
               palette={palette}
+              assetLibraries={assetLibraries}
+              onAssetLibrariesChange={setAssetLibraries}
             />
           ) : (
             <div className="w-full h-full flex relative">

--- a/src/components/AssetsPanel.tsx
+++ b/src/components/AssetsPanel.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useDeferredValue, useEffect, useMemo, useState, type ComponentProps } from "react";
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, type ComponentProps } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Input } from "./ui/input";
 import { Button } from "./ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
-import { fetchAssetLibrary } from "@/core/schema/assets";
+import { fetchAssetLibrary, fetchAmbientcgCatalog } from "@/core/schema/assets";
 import { inferAssetKind, MODEL_EXTENSIONS, TEXTURE_EXTENSIONS, ASSET_DRAG_MIME } from "@/core/assets/kind";
 import type { AssetCategory, AssetItem, AssetLibrary } from "@/core/schema/types";
 import { cn } from "@/lib/utils";
@@ -36,14 +37,32 @@ const TYPE_FILTER_OPTIONS = [
 
 type TypeFilterValue = (typeof TYPE_FILTER_OPTIONS)[number]["value"];
 
+const CARD_MIN_WIDTH = 136;
+const CARD_GAP_PX = 12;
+const CARD_ESTIMATED_HEIGHT = 236;
+const FALLBACK_RENDER_LIMIT = 48;
+
 export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps) {
   const [library, setLibrary] = useState<AssetLibrary | null>(null);
   const [userAssets, setUserAssets] = useState<AssetItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [ambientState, setAmbientState] = useState<{
+    items: AssetItem[];
+    cursor: string | null;
+    loading: boolean;
+    error: string | null;
+    generation: number;
+  }>({ items: [], cursor: null, loading: false, error: null, generation: 0 });
+  const ambientEmptyPageAttemptsRef = useRef(0);
   const [query, setQuery] = useState("");
   const [typeFilter, setTypeFilter] = useState<TypeFilterValue>("all");
   const [dragActive, setDragActive] = useState(false);
+  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);
+  const [gridWidth, setGridWidth] = useState(0);
+  const scrollRef = useCallback((node: HTMLDivElement | null) => {
+    setScrollElement(node);
+  }, []);
   const normalizedQuery = query.trim().toLowerCase();
   const deferredQuery = useDeferredValue(normalizedQuery);
   const textureHint = useMemo(() => TEXTURE_EXTENSIONS.map((ext) => `.${ext}`).slice(0, 6).join(", "), []);
@@ -58,6 +77,7 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
     return list;
   }, [assetLibraries]);
 
+  const ambientEnabled = enabledProviders.includes("ambientcg");
   const providersKey = enabledProviders.join("|");
 
   useEffect(() => {
@@ -106,6 +126,132 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
     };
   }, []);
 
+  const ambientQueryKey = useMemo(() => {
+    const parts = [ambientEnabled ? "on" : "off", typeFilter, deferredQuery];
+    return parts.join("|");
+  }, [ambientEnabled, typeFilter, deferredQuery]);
+
+  const loadMoreAmbient = useCallback(async () => {
+    if (!ambientEnabled) return;
+    let cursor: string | null | undefined;
+    let generation = 0;
+    let prevCount = 0;
+    setAmbientState((prev) => {
+      generation = prev.generation;
+      prevCount = prev.items.length;
+      if (prev.loading || !prev.cursor) {
+        cursor = null;
+        return prev;
+      }
+      cursor = prev.cursor;
+      return { ...prev, loading: true, error: null };
+    });
+    if (!cursor) return;
+    try {
+      const result = await fetchAmbientcgCatalog({ cursor, query: deferredQuery, type: typeFilter });
+      const shouldQueueMore =
+        result.items.length === 0 &&
+        !!result.cursor &&
+        prevCount === 0 &&
+        ambientEmptyPageAttemptsRef.current < 3;
+      setAmbientState((prev) => {
+        if (prev.generation !== generation) return prev;
+        return {
+          ...prev,
+          items: [...prev.items, ...result.items],
+          cursor: result.cursor,
+          loading: false,
+          error: null,
+        };
+      });
+      if (result.items.length > 0) {
+        ambientEmptyPageAttemptsRef.current = 0;
+      } else {
+        ambientEmptyPageAttemptsRef.current += 1;
+      }
+      if (shouldQueueMore) {
+        Promise.resolve().then(() => {
+          void loadMoreAmbient();
+        });
+      }
+    } catch (err) {
+      if ((err as any)?.name === "AbortError") return;
+      setAmbientState((prev) => {
+        if (prev.generation !== generation) return prev;
+        return { ...prev, loading: false, error: "Unable to load ambientCG assets." };
+      });
+    }
+  }, [ambientEnabled, deferredQuery, typeFilter]);
+
+  useEffect(() => {
+    if (!ambientEnabled) {
+      setAmbientState({ items: [], cursor: null, loading: false, error: null, generation: 0 });
+      return;
+    }
+    const ctrl = new AbortController();
+    let generation = 0;
+    ambientEmptyPageAttemptsRef.current = 0;
+    setAmbientState((prev) => {
+      const nextGeneration = prev.generation + 1;
+      generation = nextGeneration;
+      return { items: [], cursor: null, loading: true, error: null, generation: nextGeneration };
+    });
+    fetchAmbientcgCatalog({
+      signal: ctrl.signal,
+      query: deferredQuery,
+      type: typeFilter,
+    })
+      .then((result) => {
+        setAmbientState((prev) => {
+          if (prev.generation !== generation) return prev;
+          return { ...prev, items: result.items, cursor: result.cursor, loading: false, error: null };
+        });
+        if (result.items.length === 0 && result.cursor) {
+          Promise.resolve().then(() => {
+            void loadMoreAmbient();
+          });
+        }
+      })
+      .catch((err) => {
+        if (err?.name === "AbortError") return;
+        setAmbientState((prev) => {
+          if (prev.generation !== generation) return prev;
+          return { ...prev, items: [], cursor: null, loading: false, error: "Unable to load ambientCG assets." };
+        });
+      });
+    return () => {
+      ctrl.abort();
+    };
+  }, [ambientEnabled, ambientQueryKey, deferredQuery, typeFilter, loadMoreAmbient]);
+
+  useEffect(() => {
+    const element = scrollElement;
+    if (!element) return;
+
+    const updateWidth = () => {
+      setGridWidth(element.clientWidth);
+    };
+
+    updateWidth();
+
+    window.addEventListener("resize", updateWidth);
+    let observer: ResizeObserver | null = null;
+    if (typeof ResizeObserver === "function") {
+      observer = new ResizeObserver(() => updateWidth());
+      observer.observe(element);
+    }
+
+    return () => {
+      window.removeEventListener("resize", updateWidth);
+      observer?.disconnect();
+    };
+  }, [scrollElement]);
+
+  const columnCount = useMemo(() => {
+    if (!gridWidth) return 1;
+    return Math.max(1, Math.floor((gridWidth + CARD_GAP_PX) / (CARD_MIN_WIDTH + CARD_GAP_PX)));
+  }, [gridWidth]);
+
   const combinedCategories = useMemo(() => {
     const categories: AssetCategory[] = [];
     if (library) {
@@ -116,6 +262,13 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
         });
       }
     }
+    if (ambientEnabled && ambientState.items.length) {
+      categories.push({
+        id: "ambientcg",
+        label: "ambientCG",
+        items: ambientState.items.map((item) => ({ ...item, builtin: item.builtin !== false })),
+      });
+    }
     if (userAssets.length) {
       categories.push({
         id: "user",
@@ -124,7 +277,7 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
       });
     }
     return categories;
-  }, [library, userAssets]);
+  }, [library, userAssets, ambientEnabled, ambientState.items]);
 
   const allAssets = useMemo(() => {
     const list: AssetWithCategory[] = [];
@@ -157,6 +310,52 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
       })
       .map((entry) => entry.asset);
   }, [allAssets, assetSearchIndex, deferredQuery, typeFilter]);
+
+  const rowCount = useMemo(() => {
+    if (!filteredAssets.length) return 0;
+    return Math.ceil(filteredAssets.length / columnCount);
+  }, [filteredAssets, columnCount]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: rowCount,
+    getScrollElement: () => scrollElement,
+    estimateSize: () => CARD_ESTIMATED_HEIGHT,
+    overscan: 6,
+    getItemKey: (index) => filteredAssets[index * columnCount]?.id ?? `row-${index}`,
+  });
+
+  const virtualizationReady = Boolean(scrollElement && gridWidth > 0 && rowCount > 0);
+  const ambientHasMore = ambientEnabled && !!ambientState.cursor;
+  const ambientInitialLoading = ambientEnabled && ambientState.loading && ambientState.items.length === 0;
+  const combinedLoading = loading || ambientInitialLoading;
+  const ambientLoadingMore = ambientEnabled && ambientState.loading && ambientState.items.length > 0;
+  const lastVirtualIndex = virtualizationReady
+    ? rowVirtualizer.getVirtualItems()[rowVirtualizer.getVirtualItems().length - 1]?.index ?? -1
+    : -1;
+  const fallbackAssets = virtualizationReady
+    ? []
+    : filteredAssets.slice(0, Math.min(filteredAssets.length, FALLBACK_RENDER_LIMIT));
+
+  useEffect(() => {
+    if (!ambientEnabled) return;
+    if (!virtualizationReady) return;
+    if (!ambientHasMore) return;
+    if (ambientLoadingMore) return;
+    if (lastVirtualIndex < 0) return;
+    const threshold = filteredAssets.length - columnCount * 2;
+    if (threshold <= 0 || lastVirtualIndex >= threshold) {
+      void loadMoreAmbient();
+    }
+  }, [
+    ambientEnabled,
+    ambientHasMore,
+    ambientLoadingMore,
+    lastVirtualIndex,
+    filteredAssets.length,
+    columnCount,
+    virtualizationReady,
+    loadMoreAmbient,
+  ]);
 
   const updateUserAssets = useCallback((updater: (prev: AssetItem[]) => AssetItem[]) => {
     setUserAssets((prev) => {
@@ -227,6 +426,120 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
     event.dataTransfer.setData(ASSET_DRAG_MIME, serializeAsset(asset));
   }, []);
 
+  const renderAssetCard = useCallback(
+    (asset: AssetWithCategory) => {
+      const isTexture = asset.type === "texture";
+      const draggable = asset.type === "texture" || asset.type === "model";
+      const previewSrc = asset.preview ?? (isTexture ? asset.source : undefined);
+      const providerName = asset.provider?.name ?? null;
+      const providerLink = asset.provider?.assetUrl ?? null;
+      return (
+        <div
+          key={`${asset.category.id}:${asset.id}`}
+          className="group relative flex h-full flex-col gap-2 rounded-md border border-border/70 bg-background/90 p-2 shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-[border-color,box-shadow,transform] hover:-translate-y-[1px] hover:border-primary/60"
+          draggable={draggable}
+          data-node-interactive
+          onPointerDownCapture={(event) => event.stopPropagation()}
+          onDragStart={(event) => {
+            event.stopPropagation();
+            startDrag(event, asset);
+          }}
+        >
+          <div className="relative aspect-square w-full overflow-hidden rounded-sm border border-muted/60 bg-muted">
+            {previewSrc ? (
+              <img
+                src={previewSrc}
+                alt={asset.label}
+                className="size-full object-cover"
+                loading="lazy"
+                decoding="async"
+                crossOrigin="anonymous"
+                draggable={false}
+              />
+            ) : isTexture ? (
+              <img
+                src={asset.source}
+                alt={asset.label}
+                className="size-full object-cover"
+                loading="lazy"
+                decoding="async"
+                crossOrigin="anonymous"
+                draggable={false}
+              />
+            ) : (
+              <div className="flex size-full items-center justify-center text-muted-foreground">
+                <Box className="size-8" strokeWidth={1.5} />
+              </div>
+            )}
+            {!asset.builtin ? (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="absolute right-1 top-1 size-7 rounded-full border border-border/50 bg-background/80 opacity-0 transition-opacity group-hover:opacity-100"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  removeUserAsset(asset.id);
+                }}
+                onPointerDown={(event) => event.stopPropagation()}
+                title="Remove from My Assets"
+              >
+                <Trash2 className="size-3.5" />
+              </Button>
+            ) : null}
+          </div>
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <div className="truncate text-xs font-medium leading-tight">{asset.label}</div>
+              <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                {providerName ? (
+                  <span className="flex items-center gap-1">
+                    <span>{providerName}</span>
+                    <span>•</span>
+                    <span className="truncate">{asset.category.label}</span>
+                  </span>
+                ) : (
+                  asset.category.label
+                )}
+              </div>
+            </div>
+            <div className="flex items-center gap-1">
+              <TypeBadge type={asset.type} />
+              {providerLink ? (
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="size-7 opacity-0 transition-opacity group-hover:opacity-100"
+                  title="Open provider page"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    try {
+                      window.open(providerLink, "_blank", "noopener,noreferrer");
+                    } catch (_err) {
+                      /* ignore */
+                    }
+                  }}
+                  onPointerDown={(event) => event.stopPropagation()}
+                >
+                  <ExternalLink className="size-3.5" />
+                </Button>
+              ) : null}
+              <CopySourceButton
+                source={asset.source}
+                size="icon"
+                variant="ghost"
+                className="size-7 opacity-0 transition-opacity group-hover:opacity-100"
+                title="Copy asset path"
+              />
+            </div>
+          </div>
+        </div>
+      );
+    },
+    [removeUserAsset, startDrag]
+  );
+
   const body = (
     <div className="flex flex-col gap-3 h-full nodrag nowheel" data-node-interactive>
       <div className="flex flex-col gap-3">
@@ -273,127 +586,68 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
           <div className="border-b border-dashed border-muted/80 px-3 py-2 text-[11px] leading-5 text-muted-foreground">
             Drag textures ({textureHint}, …) or models ({modelHint}, …) here to store them locally. Imported assets stay in your browser.
           </div>
-          <div className="flex-1 overflow-auto p-3" onWheel={(event) => event.stopPropagation()} data-node-interactive>
-            {loading ? (
+          <div
+            ref={scrollRef}
+            className="flex-1 overflow-auto p-3"
+            onWheel={(event) => event.stopPropagation()}
+            data-node-interactive
+          >
+            {combinedLoading ? (
               <div className="p-4 text-xs text-muted-foreground">Loading assets…</div>
             ) : error ? (
               <div className="p-4 text-xs text-destructive" role="alert">
                 {error}
               </div>
+            ) : ambientState.error && !ambientState.items.length ? (
+              <div className="p-4 text-xs text-destructive" role="alert">
+                {ambientState.error}
+              </div>
             ) : filteredAssets.length === 0 ? (
               <div className="p-4 text-xs text-muted-foreground">No assets match the current filter.</div>
+            ) : virtualizationReady ? (
+              <div className="relative w-full">
+                <div style={{ height: rowVirtualizer.getTotalSize(), position: "relative" }}>
+                  {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                    const startIndex = virtualRow.index * columnCount;
+                    const rowAssets = filteredAssets.slice(startIndex, startIndex + columnCount);
+                    if (!rowAssets.length) return null;
+                    return (
+                      <div
+                        key={virtualRow.key}
+                        data-index={virtualRow.index}
+                        style={{
+                          position: "absolute",
+                          top: 0,
+                          left: 0,
+                          width: "100%",
+                          transform: `translateY(${virtualRow.start}px)`,
+                          height: virtualRow.size,
+                          paddingBottom: CARD_GAP_PX,
+                          boxSizing: "border-box",
+                        }}
+                      >
+                        <div
+                          className="grid gap-3"
+                          style={{ gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))` }}
+                        >
+                          {rowAssets.map(renderAssetCard)}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+                {ambientLoadingMore ? (
+                  <div className="px-2 py-3 text-center text-[11px] text-muted-foreground">Loading more assets…</div>
+                ) : null}
+                {ambientState.error && ambientState.items.length ? (
+                  <div className="px-2 pb-3 text-center text-[11px] text-destructive" role="alert">
+                    {ambientState.error}
+                  </div>
+                ) : null}
+              </div>
             ) : (
               <div className="grid grid-cols-[repeat(auto-fill,minmax(136px,1fr))] gap-3">
-                {filteredAssets.map((asset) => {
-                  const isTexture = asset.type === "texture";
-                  const draggable = asset.type === "texture" || asset.type === "model";
-                  const previewSrc = asset.preview ?? (isTexture ? asset.source : undefined);
-                  const providerName = asset.provider?.name ?? null;
-                  const providerLink = asset.provider?.assetUrl ?? null;
-                  return (
-                    <div
-                      key={`${asset.category.id}:${asset.id}`}
-                      className="group relative flex h-full flex-col gap-2 rounded-md border border-border/70 bg-background/90 p-2 shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-[border-color,box-shadow,transform] hover:-translate-y-[1px] hover:border-primary/60"
-                      draggable={draggable}
-                      data-node-interactive
-                      onPointerDownCapture={(event) => event.stopPropagation()}
-                      onDragStart={(event) => {
-                        event.stopPropagation();
-                        startDrag(event, asset);
-                      }}
-                    >
-                      <div className="relative aspect-square w-full overflow-hidden rounded-sm border border-muted/60 bg-muted">
-                        {previewSrc ? (
-                          <img
-                            src={previewSrc}
-                            alt={asset.label}
-                            className="size-full object-cover"
-                            loading="lazy"
-                            decoding="async"
-                            crossOrigin="anonymous"
-                            draggable={false}
-                          />
-                        ) : isTexture ? (
-                          <img
-                            src={asset.source}
-                            alt={asset.label}
-                            className="size-full object-cover"
-                            loading="lazy"
-                            decoding="async"
-                            crossOrigin="anonymous"
-                            draggable={false}
-                          />
-                        ) : (
-                          <div className="flex size-full items-center justify-center text-muted-foreground">
-                            <Box className="size-8" strokeWidth={1.5} />
-                          </div>
-                        )}
-                        {!asset.builtin ? (
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="absolute right-1 top-1 size-7 rounded-full border border-border/50 bg-background/80 opacity-0 transition-opacity group-hover:opacity-100"
-                            onClick={(event) => {
-                              event.preventDefault();
-                              event.stopPropagation();
-                              removeUserAsset(asset.id);
-                            }}
-                            onPointerDown={(event) => event.stopPropagation()}
-                            title="Remove from My Assets"
-                          >
-                            <Trash2 className="size-3.5" />
-                          </Button>
-                        ) : null}
-                      </div>
-                      <div className="flex items-start justify-between gap-2">
-                        <div className="min-w-0">
-                          <div className="truncate text-xs font-medium leading-tight">{asset.label}</div>
-                          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                            {providerName ? (
-                              <span className="flex items-center gap-1">
-                                <span>{providerName}</span>
-                                <span>•</span>
-                                <span className="truncate">{asset.category.label}</span>
-                              </span>
-                            ) : (
-                              asset.category.label
-                            )}
-                          </div>
-                        </div>
-                        <div className="flex items-center gap-1">
-                          <TypeBadge type={asset.type} />
-                          {providerLink ? (
-                            <Button
-                              size="icon"
-                              variant="ghost"
-                              className="size-7 opacity-0 transition-opacity group-hover:opacity-100"
-                              title="Open provider page"
-                              onClick={(event) => {
-                                event.preventDefault();
-                                event.stopPropagation();
-                                try {
-                                  window.open(providerLink, "_blank", "noopener,noreferrer");
-                                } catch (_err) {
-                                  /* ignore */
-                                }
-                              }}
-                              onPointerDown={(event) => event.stopPropagation()}
-                            >
-                              <ExternalLink className="size-3.5" />
-                            </Button>
-                          ) : null}
-                          <CopySourceButton
-                            source={asset.source}
-                            size="icon"
-                            variant="ghost"
-                            className="size-7 opacity-0 transition-opacity group-hover:opacity-100"
-                            title="Copy asset path"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  );
-                })}
+                {fallbackAssets.map(renderAssetCard)}
               </div>
             )}
           </div>

--- a/src/components/AssetsPanel.tsx
+++ b/src/components/AssetsPanel.tsx
@@ -2,13 +2,15 @@ import { useCallback, useDeferredValue, useEffect, useMemo, useState, type Compo
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Input } from "./ui/input";
 import { Button } from "./ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 import { fetchAssetLibrary } from "@/core/schema/assets";
 import { inferAssetKind, MODEL_EXTENSIONS, TEXTURE_EXTENSIONS, ASSET_DRAG_MIME } from "@/core/assets/kind";
 import type { AssetCategory, AssetItem, AssetLibrary } from "@/core/schema/types";
 import { cn } from "@/lib/utils";
 import { persistGet, persistSet } from "@/lib/storage";
-import { Check, Copy, Box, Image as ImageIcon, Trash2 } from "lucide-react";
+import { Check, Copy, Box, Image as ImageIcon, Trash2, ExternalLink } from "lucide-react";
 import { buildAssetHaystack, type AssetWithCategory } from "@/core/assets/search";
+import { useSettings } from "@/ui/state/SettingsContext";
 
 function readFileAsDataUrl(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -26,22 +28,42 @@ export type AssetsPanelProps = {
 
 const USER_ASSETS_STORAGE_KEY = "assets.user";
 
+const TYPE_FILTER_OPTIONS = [
+  { value: "all", label: "All" },
+  { value: "texture", label: "Textures" },
+  { value: "model", label: "Models" },
+] as const;
+
+type TypeFilterValue = (typeof TYPE_FILTER_OPTIONS)[number]["value"];
+
 export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps) {
   const [library, setLibrary] = useState<AssetLibrary | null>(null);
   const [userAssets, setUserAssets] = useState<AssetItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
+  const [typeFilter, setTypeFilter] = useState<TypeFilterValue>("all");
   const [dragActive, setDragActive] = useState(false);
   const normalizedQuery = query.trim().toLowerCase();
   const deferredQuery = useDeferredValue(normalizedQuery);
   const textureHint = useMemo(() => TEXTURE_EXTENSIONS.map((ext) => `.${ext}`).slice(0, 6).join(", "), []);
   const modelHint = useMemo(() => MODEL_EXTENSIONS.map((ext) => `.${ext}`).slice(0, 6).join(", "), []);
+  const { assetLibraries } = useSettings();
+
+  const enabledProviders = useMemo(() => {
+    const list: string[] = [];
+    if (assetLibraries?.ambientcg?.enabled) {
+      list.push("ambientcg");
+    }
+    return list;
+  }, [assetLibraries]);
+
+  const providersKey = enabledProviders.join("|");
 
   useEffect(() => {
     const ctrl = new AbortController();
     setLoading(true);
-    fetchAssetLibrary(ctrl.signal)
+    fetchAssetLibrary({ signal: ctrl.signal, providers: enabledProviders })
       .then((data) => {
         const normalized: AssetLibrary = {
           ...data,
@@ -63,7 +85,7 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
         setLoading(false);
       });
     return () => ctrl.abort();
-  }, []);
+  }, [providersKey, enabledProviders]);
 
   useEffect(() => {
     let cancelled = false;
@@ -124,11 +146,17 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
   );
 
   const filteredAssets = useMemo(() => {
-    if (!deferredQuery) return allAssets;
+    if (!deferredQuery && typeFilter === "all") return allAssets;
+    if (!deferredQuery) {
+      return allAssets.filter((asset) => (typeFilter === "all" ? true : asset.type === typeFilter));
+    }
     return assetSearchIndex
-      .filter((entry) => entry.haystack.includes(deferredQuery))
+      .filter((entry) => {
+        if (typeFilter !== "all" && entry.asset.type !== typeFilter) return false;
+        return entry.haystack.includes(deferredQuery);
+      })
       .map((entry) => entry.asset);
-  }, [allAssets, assetSearchIndex, deferredQuery]);
+  }, [allAssets, assetSearchIndex, deferredQuery, typeFilter]);
 
   const updateUserAssets = useCallback((updater: (prev: AssetItem[]) => AssetItem[]) => {
     setUserAssets((prev) => {
@@ -163,6 +191,7 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
           description: kind === "texture" ? "User imported texture asset." : "User imported model asset.",
           tags: ["user", kind],
           builtin: false,
+          preview: dataUrl,
         });
       }
 
@@ -200,13 +229,38 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
 
   const body = (
     <div className="flex flex-col gap-3 h-full nodrag nowheel" data-node-interactive>
-      <div className="flex flex-col gap-2">
-        <label className="text-xs text-muted-foreground">Search assets</label>
-        <Input
-          placeholder="Filter by name, tag, or type"
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-        />
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div className="flex flex-col gap-2 sm:flex-1">
+            <label className="text-xs text-muted-foreground">Search assets</label>
+            <Input
+              placeholder="Filter by name, tag, or provider"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          </div>
+          <div className="flex flex-col gap-2 sm:w-44">
+            <label className="text-xs text-muted-foreground">Type</label>
+            <Select value={typeFilter} onValueChange={(val) => setTypeFilter(val as TypeFilterValue)}>
+              <SelectTrigger>
+                <SelectValue placeholder="All" />
+              </SelectTrigger>
+              <SelectContent>
+                {TYPE_FILTER_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        {enabledProviders.length ? (
+          <p className="text-[11px] leading-4 text-muted-foreground">
+            Showing built-in assets{" "}
+            {enabledProviders.includes("ambientcg") ? "and ambientCG library" : ""}.
+          </p>
+        ) : null}
       </div>
       <div
         {...dragProps}
@@ -233,6 +287,9 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
                 {filteredAssets.map((asset) => {
                   const isTexture = asset.type === "texture";
                   const draggable = asset.type === "texture" || asset.type === "model";
+                  const previewSrc = asset.preview ?? (isTexture ? asset.source : undefined);
+                  const providerName = asset.provider?.name ?? null;
+                  const providerLink = asset.provider?.assetUrl ?? null;
                   return (
                     <div
                       key={`${asset.category.id}:${asset.id}`}
@@ -246,7 +303,17 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
                       }}
                     >
                       <div className="relative aspect-square w-full overflow-hidden rounded-sm border border-muted/60 bg-muted">
-                        {isTexture ? (
+                        {previewSrc ? (
+                          <img
+                            src={previewSrc}
+                            alt={asset.label}
+                            className="size-full object-cover"
+                            loading="lazy"
+                            decoding="async"
+                            crossOrigin="anonymous"
+                            draggable={false}
+                          />
+                        ) : isTexture ? (
                           <img
                             src={asset.source}
                             alt={asset.label}
@@ -282,11 +349,39 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
                         <div className="min-w-0">
                           <div className="truncate text-xs font-medium leading-tight">{asset.label}</div>
                           <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                            {asset.category.label}
+                            {providerName ? (
+                              <span className="flex items-center gap-1">
+                                <span>{providerName}</span>
+                                <span>•</span>
+                                <span className="truncate">{asset.category.label}</span>
+                              </span>
+                            ) : (
+                              asset.category.label
+                            )}
                           </div>
                         </div>
                         <div className="flex items-center gap-1">
                           <TypeBadge type={asset.type} />
+                          {providerLink ? (
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="size-7 opacity-0 transition-opacity group-hover:opacity-100"
+                              title="Open provider page"
+                              onClick={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                try {
+                                  window.open(providerLink, "_blank", "noopener,noreferrer");
+                                } catch (_err) {
+                                  /* ignore */
+                                }
+                              }}
+                              onPointerDown={(event) => event.stopPropagation()}
+                            >
+                              <ExternalLink className="size-3.5" />
+                            </Button>
+                          ) : null}
                           <CopySourceButton
                             source={asset.source}
                             size="icon"

--- a/src/components/AssetsPanel.tsx
+++ b/src/components/AssetsPanel.tsx
@@ -8,10 +8,17 @@ import { fetchAssetLibrary, fetchAmbientcgCatalog } from "@/core/schema/assets";
 import { inferAssetKind, MODEL_EXTENSIONS, TEXTURE_EXTENSIONS, ASSET_DRAG_MIME } from "@/core/assets/kind";
 import type { AssetCategory, AssetItem, AssetLibrary } from "@/core/schema/types";
 import { cn } from "@/lib/utils";
-import { persistGet, persistSet } from "@/lib/storage";
 import { Check, Copy, Box, Image as ImageIcon, Trash2, ExternalLink } from "lucide-react";
 import { buildAssetHaystack, type AssetWithCategory } from "@/core/assets/search";
 import { useSettings } from "@/ui/state/SettingsContext";
+import {
+  appendUserAsset,
+  createUserAssetId,
+  loadUserAssets,
+  removeUserAssetById,
+  saveUserAssets,
+  USER_ASSETS_CHANGED_EVENT,
+} from "@/core/assets/userAssets";
 
 function readFileAsDataUrl(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -26,8 +33,6 @@ export type AssetsPanelProps = {
   className?: string;
   variant?: "docked" | "overlay" | "node";
 };
-
-const USER_ASSETS_STORAGE_KEY = "assets.user";
 
 const TYPE_FILTER_OPTIONS = [
   { value: "all", label: "All" },
@@ -111,18 +116,28 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
     let cancelled = false;
     (async () => {
       try {
-        const stored = await persistGet<AssetItem[]>(USER_ASSETS_STORAGE_KEY);
-        if (cancelled || !stored) return;
-        const normalized = stored
-          .filter((asset): asset is AssetItem => !!asset && typeof asset.id === "string" && typeof asset.source === "string")
-          .map((asset) => ({ ...asset, builtin: false }));
-        setUserAssets(normalized);
+        const stored = await loadUserAssets();
+        if (cancelled) return;
+        setUserAssets(stored.map((asset) => ({ ...asset, builtin: false })));
       } catch (err) {
         console.warn("Failed to load user assets", err);
       }
     })();
     return () => {
       cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const listener = (event: Event) => {
+      const detail = (event as CustomEvent<AssetItem[]>).detail;
+      if (!Array.isArray(detail)) return;
+      setUserAssets(detail.map((asset) => ({ ...asset, builtin: false })));
+    };
+    window.addEventListener(USER_ASSETS_CHANGED_EVENT, listener as EventListener);
+    return () => {
+      window.removeEventListener(USER_ASSETS_CHANGED_EVENT, listener as EventListener);
     };
   }, []);
 
@@ -360,13 +375,15 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
   const updateUserAssets = useCallback((updater: (prev: AssetItem[]) => AssetItem[]) => {
     setUserAssets((prev) => {
       const next = updater(prev).map((asset) => ({ ...asset, builtin: false }));
-      void persistSet(USER_ASSETS_STORAGE_KEY, next);
+      void saveUserAssets(next).catch((err) => {
+        console.warn("Failed to persist user assets", err);
+      });
       return next;
     });
   }, []);
 
   const removeUserAsset = useCallback((id: string) => {
-    updateUserAssets((prev) => prev.filter((asset) => asset.id !== id));
+    updateUserAssets((prev) => removeUserAssetById(prev, id));
   }, [updateUserAssets]);
 
   const handleDrop = useCallback(
@@ -383,7 +400,7 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
         const dataUrl = await readFileAsDataUrl(file).catch(() => null);
         if (!dataUrl) continue;
         additions.push({
-          id: `user-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
+          id: createUserAssetId(),
           label: file.name,
           type: kind,
           source: dataUrl,
@@ -395,7 +412,7 @@ export function AssetsPanel({ className, variant = "docked" }: AssetsPanelProps)
       }
 
       if (!additions.length) return;
-      updateUserAssets((prev) => [...prev, ...additions]);
+      updateUserAssets((prev) => additions.reduce((acc, asset) => appendUserAsset(acc, asset), prev));
     },
     [updateUserAssets]
   );

--- a/src/core/assets/registry.ts
+++ b/src/core/assets/registry.ts
@@ -1,5 +1,5 @@
 import type { AssetItem } from "@/core/schema/types";
-import { fetchAssetLibrary } from "@/core/schema/assets";
+import { fetchAssetLibrary, type FetchAssetLibraryOptions } from "@/core/schema/assets";
 import { persistGet } from "@/lib/storage";
 
 export type AssetRegistryEntry = {
@@ -8,6 +8,8 @@ export type AssetRegistryEntry = {
   label?: string;
   type?: string;
   builtin?: boolean;
+  preview?: string;
+  provider?: AssetItem["provider"];
 };
 
 export type AssetRegistry = {
@@ -17,7 +19,7 @@ export type AssetRegistry = {
 
 const USER_ASSETS_STORAGE_KEY = "assets.user";
 
-export async function loadAssetRegistry(): Promise<AssetRegistry> {
+export async function loadAssetRegistry(options?: FetchAssetLibraryOptions): Promise<AssetRegistry> {
   const byId = new Map<string, AssetRegistryEntry>();
   const bySource = new Map<string, AssetRegistryEntry>();
 
@@ -28,7 +30,7 @@ export async function loadAssetRegistry(): Promise<AssetRegistry> {
   };
 
   try {
-    const library = await fetchAssetLibrary();
+    const library = await fetchAssetLibrary(options);
     for (const category of library.categories ?? []) {
       for (const item of category.items ?? []) {
         if (!item || typeof item.id !== "string" || typeof item.source !== "string") continue;
@@ -38,6 +40,8 @@ export async function loadAssetRegistry(): Promise<AssetRegistry> {
           label: item.label,
           type: item.type,
           builtin: item.builtin !== false,
+          preview: item.preview,
+          provider: item.provider,
         });
       }
     }
@@ -49,14 +53,16 @@ export async function loadAssetRegistry(): Promise<AssetRegistry> {
     const stored = await persistGet<AssetItem[]>(USER_ASSETS_STORAGE_KEY);
     for (const item of stored ?? []) {
       if (!item || typeof item.id !== "string" || typeof item.source !== "string") continue;
-      register({
-        id: item.id,
-        source: item.source,
-        label: item.label,
-        type: item.type,
-        builtin: false,
-      });
-    }
+        register({
+          id: item.id,
+          source: item.source,
+          label: item.label,
+          type: item.type,
+          builtin: false,
+          preview: item.preview,
+          provider: item.provider,
+        });
+      }
   } catch (err) {
     console.warn("Failed to load user assets while building registry", err);
   }

--- a/src/core/assets/search.ts
+++ b/src/core/assets/search.ts
@@ -10,6 +10,8 @@ export function buildAssetHaystack(asset: AssetWithCategory): string {
     ...(asset.tags ?? []),
     asset.description ?? "",
     asset.category?.label ?? "",
+    asset.provider?.name ?? "",
+    asset.provider?.assetId ?? "",
   ]
     .join(" ")
     .toLowerCase();

--- a/src/core/assets/userAssets.ts
+++ b/src/core/assets/userAssets.ts
@@ -1,0 +1,80 @@
+import type { AssetItem } from "@/core/schema/types";
+import { persistGet, persistSet } from "@/lib/storage";
+
+export const USER_ASSETS_STORAGE_KEY = "assets.user";
+export const USER_ASSETS_CHANGED_EVENT = "osg:user-assets:changed";
+
+function notifyUserAssetsChanged(list: AssetItem[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.dispatchEvent(new CustomEvent(USER_ASSETS_CHANGED_EVENT, { detail: list }));
+  } catch {
+    // ignore
+  }
+}
+
+function isAssetCandidate(value: unknown): value is AssetItem {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<AssetItem>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.label === "string" &&
+    typeof candidate.type === "string" &&
+    typeof candidate.source === "string"
+  );
+}
+
+function normalizeUserAsset(asset: AssetItem): AssetItem {
+  return {
+    ...asset,
+    builtin: false,
+  };
+}
+
+function sanitizeUserAssetList(list: unknown): AssetItem[] {
+  if (!Array.isArray(list)) return [];
+  const normalized: AssetItem[] = [];
+  for (const item of list) {
+    if (!isAssetCandidate(item)) continue;
+    const type = item.type === "model" ? "model" : "texture";
+    const label = item.label.trim().length > 0 ? item.label.trim() : item.source;
+    normalized.push(
+      normalizeUserAsset({
+        ...item,
+        type,
+        label,
+        description:
+          item.description ??
+          (type === "texture" ? "User provided texture asset." : "User provided model asset."),
+        tags: Array.isArray(item.tags) && item.tags.length ? item.tags : ["user", type],
+      })
+    );
+  }
+  return normalized;
+}
+
+export async function loadUserAssets(): Promise<AssetItem[]> {
+  const stored = await persistGet<AssetItem[] | null>(USER_ASSETS_STORAGE_KEY).catch(() => null);
+  return sanitizeUserAssetList(stored ?? []);
+}
+
+export async function saveUserAssets(assets: AssetItem[]): Promise<void> {
+  const sanitized = sanitizeUserAssetList(assets);
+  await persistSet(USER_ASSETS_STORAGE_KEY, sanitized);
+  notifyUserAssetsChanged(sanitized);
+}
+
+export function createUserAssetId(): string {
+  const random = Math.random().toString(16).slice(2, 10);
+  return `user-${Date.now()}-${random}`;
+}
+
+export function appendUserAsset(list: AssetItem[], asset: AssetItem): AssetItem[] {
+  return [...list, normalizeUserAsset(asset)];
+}
+
+export function removeUserAssetById(list: AssetItem[], id: string): AssetItem[] {
+  return list.filter((asset) => asset.id !== id);
+}
+
+export type { AssetItem };

--- a/src/core/schema/assets.ts
+++ b/src/core/schema/assets.ts
@@ -1,8 +1,23 @@
 import type { AssetLibrary } from "./types";
 import { validateAssetLibrary } from "./validators";
 
-export async function fetchAssetLibrary(signal?: AbortSignal): Promise<AssetLibrary> {
-  const res = await fetch("/api/assets", signal ? { signal } : undefined);
+export type FetchAssetLibraryOptions = {
+  signal?: AbortSignal;
+  providers?: string[];
+};
+
+export async function fetchAssetLibrary(options?: FetchAssetLibraryOptions): Promise<AssetLibrary> {
+  const signal = options?.signal;
+  const rawProviders = Array.isArray(options?.providers) ? options.providers : [];
+  const providers = rawProviders
+    .map((id) => (typeof id === "string" ? id.trim() : ""))
+    .filter((id) => id.length > 0);
+  const params = new URLSearchParams();
+  for (const provider of providers) {
+    params.append("provider", provider);
+  }
+  const query = params.toString();
+  const res = await fetch(`/api/assets${query ? `?${query}` : ""}`, signal ? { signal } : undefined);
   if (!res.ok) throw new Error(`Failed to load asset library: ${res.status}`);
   const data = await res.json();
   return validateAssetLibrary(data);

--- a/src/core/schema/assets.ts
+++ b/src/core/schema/assets.ts
@@ -1,4 +1,4 @@
-import type { AssetLibrary } from "./types";
+import type { AssetItem, AssetLibrary } from "./types";
 import { validateAssetLibrary } from "./validators";
 
 export type FetchAssetLibraryOptions = {
@@ -21,4 +21,43 @@ export async function fetchAssetLibrary(options?: FetchAssetLibraryOptions): Pro
   if (!res.ok) throw new Error(`Failed to load asset library: ${res.status}`);
   const data = await res.json();
   return validateAssetLibrary(data);
+}
+
+export type FetchAmbientcgCatalogOptions = {
+  signal?: AbortSignal;
+  cursor?: string | null;
+  query?: string;
+  type?: "texture" | "model" | "all";
+};
+
+export type AmbientcgCatalogResponse = {
+  items: AssetItem[];
+  cursor: string | null;
+};
+
+export async function fetchAmbientcgCatalog(options?: FetchAmbientcgCatalogOptions): Promise<AmbientcgCatalogResponse> {
+  const signal = options?.signal;
+  const params = new URLSearchParams();
+  if (options?.cursor) {
+    params.set("cursor", options.cursor);
+  }
+  if (options?.query) {
+    params.set("query", options.query);
+  }
+  if (options?.type) {
+    params.set("type", options.type);
+  }
+  const query = params.toString();
+  const res = await fetch(`/api/assets/ambientcg/catalog${query ? `?${query}` : ""}`, signal ? { signal } : undefined);
+  if (!res.ok) throw new Error(`Failed to load ambientCG catalog: ${res.status}`);
+  const data = await res.json();
+  const cursor = typeof data?.cursor === "string" && data.cursor.length ? data.cursor : null;
+  const items = Array.isArray(data?.items)
+    ? data.items
+        .filter((item: any): item is AssetItem => {
+          return item && typeof item.id === "string" && typeof item.label === "string" && typeof item.source === "string";
+        })
+        .map((item: AssetItem) => ({ ...item, builtin: item.builtin !== false } as AssetItem))
+    : [];
+  return { items, cursor };
 }

--- a/src/core/schema/types.ts
+++ b/src/core/schema/types.ts
@@ -107,6 +107,13 @@ export type LanguagePack = {
 
 export type AssetKind = "texture" | "model" | string;
 
+export type AssetProviderMeta = {
+  id: string;
+  name: string;
+  assetId?: string;
+  assetUrl?: string;
+};
+
 export type AssetItem = {
   id: string;
   label: string;
@@ -115,6 +122,8 @@ export type AssetItem = {
   description?: string;
   tags?: string[];
   builtin?: boolean;
+  preview?: string;
+  provider?: AssetProviderMeta;
 };
 
 export type AssetCategory = {

--- a/src/core/schema/validators.ts
+++ b/src/core/schema/validators.ts
@@ -169,6 +169,13 @@ export const ZLanguagePack = z.object({
   meta: z.record(z.object({ template: z.union([z.string(), z.array(z.string())]) })).optional(),
 });
 
+const ZAssetProviderMeta = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  assetId: z.string().min(1).optional(),
+  assetUrl: z.string().min(1).optional(),
+});
+
 const ZAssetItem = z.object({
   id: z.string().min(1),
   label: z.string().min(1),
@@ -177,6 +184,8 @@ const ZAssetItem = z.object({
   description: z.string().optional(),
   tags: z.array(z.string().min(1)).optional(),
   builtin: z.boolean().optional(),
+  preview: z.string().min(1).optional(),
+  provider: ZAssetProviderMeta.optional(),
 });
 
 const ZAssetCategory = z.object({

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -1,13 +1,9 @@
 import { promises as fs } from "fs";
 import path from "path";
 import { validateAssetLibrary } from "../core/schema/validators";
-import { AMBIENT_CG_PROVIDER_ID, loadAmbientcgCategories } from "./providers/ambientcg";
 
-export async function assetsHandler(req: Request): Promise<Response> {
+export async function assetsHandler(_req: Request): Promise<Response> {
   try {
-    const url = new URL(req.url);
-    const providerParams = url.searchParams.getAll("provider");
-    const providerSet = new Set(providerParams.map((p) => p.trim().toLowerCase()).filter(Boolean));
     const abs = path.resolve(process.cwd(), "data", "assets", "library.json");
     try {
       const st = await fs.stat(abs);
@@ -27,20 +23,6 @@ export async function assetsHandler(req: Request): Promise<Response> {
         items: category.items.map((item) => ({ ...item, builtin: true })),
       })),
     };
-
-    if (providerSet.has(AMBIENT_CG_PROVIDER_ID)) {
-      try {
-        const ambientCategories = await loadAmbientcgCategories();
-        for (const category of ambientCategories) {
-          withBuiltin.categories.push({
-            ...category,
-            items: category.items.map((item) => ({ ...item, builtin: true })),
-          });
-        }
-      } catch (err) {
-        console.error("[ambientcg] failed to load library", err);
-      }
-    }
 
     return Response.json(withBuiltin);
   } catch (err) {

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -1,9 +1,13 @@
 import { promises as fs } from "fs";
 import path from "path";
 import { validateAssetLibrary } from "../core/schema/validators";
+import { AMBIENT_CG_PROVIDER_ID, loadAmbientcgCategories } from "./providers/ambientcg";
 
-export async function assetsHandler(): Promise<Response> {
+export async function assetsHandler(req: Request): Promise<Response> {
   try {
+    const url = new URL(req.url);
+    const providerParams = url.searchParams.getAll("provider");
+    const providerSet = new Set(providerParams.map((p) => p.trim().toLowerCase()).filter(Boolean));
     const abs = path.resolve(process.cwd(), "data", "assets", "library.json");
     try {
       const st = await fs.stat(abs);
@@ -23,6 +27,21 @@ export async function assetsHandler(): Promise<Response> {
         items: category.items.map((item) => ({ ...item, builtin: true })),
       })),
     };
+
+    if (providerSet.has(AMBIENT_CG_PROVIDER_ID)) {
+      try {
+        const ambientCategories = await loadAmbientcgCategories();
+        for (const category of ambientCategories) {
+          withBuiltin.categories.push({
+            ...category,
+            items: category.items.map((item) => ({ ...item, builtin: true })),
+          });
+        }
+      } catch (err) {
+        console.error("[ambientcg] failed to load library", err);
+      }
+    }
+
     return Response.json(withBuiltin);
   } catch (err) {
     console.error("/api/assets failed:", err);

--- a/src/server/providers/ambientcg.ts
+++ b/src/server/providers/ambientcg.ts
@@ -1,13 +1,13 @@
 import { unzipSync } from "fflate";
-import type { AssetCategory, AssetItem } from "../../core/schema/types";
+import type { AssetItem } from "../../core/schema/types";
 
 export const AMBIENT_CG_PROVIDER_ID = "ambientcg";
 export const AMBIENT_CG_PROVIDER_NAME = "ambientCG";
 
 const API_BASE_URL = "https://ambientcg.com/api/v2/full_json";
-const API_INCLUDE = "downloadData,mapData,previewData";
-const PAGE_SIZE = 128;
-const LIBRARY_CACHE_TTL_MS = 30 * 60 * 1000;
+const API_INCLUDE = "downloadData,previewData";
+const PAGE_SIZE = 96;
+const PAGE_CACHE_TTL_MS = 30 * 60 * 1000;
 const ZIP_CACHE_TTL_MS = 10 * 60 * 1000;
 
 const MODEL_FILE_EXTENSIONS = new Set(["usdc", "usd", "usdz", "glb", "gltf", "obj", "fbx"]);
@@ -68,18 +68,12 @@ type AmbientcgAsset = {
 type AmbientcgApiResponse = {
   foundAssets?: AmbientcgAsset[];
   nextPageHttp?: string | null;
-  numberOfResults?: number;
 };
 
-type AmbientcgLibrary = {
-  textures: AssetItem[];
-  models: AssetItem[];
-};
-
-type LibraryCacheState = {
+type AmbientcgPageCacheEntry = {
   expiresAt: number;
-  value: AmbientcgLibrary | null;
-  promise: Promise<AmbientcgLibrary> | null;
+  assets: AmbientcgAsset[];
+  nextOffset: number | null;
 };
 
 type ZipCacheEntry = {
@@ -89,12 +83,7 @@ type ZipCacheEntry = {
   filename: string;
 };
 
-const libraryCache: LibraryCacheState = {
-  expiresAt: 0,
-  value: null,
-  promise: null,
-};
-
+const pageCache = new Map<string, AmbientcgPageCacheEntry>();
 const zipCache = new Map<string, ZipCacheEntry>();
 
 function slugify(value: string | undefined | null): string {
@@ -260,94 +249,101 @@ function selectModelDownloads(asset: AmbientcgAsset): Array<{ download: Ambientc
   return selections;
 }
 
-function mapAsset(asset: AmbientcgAsset): AmbientcgLibrary {
+type AmbientcgItemType = "all" | "texture" | "model";
+
+function mapAmbientcgAsset(asset: AmbientcgAsset, filter: AmbientcgItemType): AssetItem[] {
   const provider = {
     id: AMBIENT_CG_PROVIDER_ID,
     name: AMBIENT_CG_PROVIDER_NAME,
     assetId: asset.assetId,
     assetUrl: asset.shortLink,
-  };
+  } as const;
   const previewImage = pickPreviewImage(asset.previewImage);
-  const textures: AssetItem[] = [];
-  const models: AssetItem[] = [];
+  const items: AssetItem[] = [];
+  const allowTextures = filter === "all" || filter === "texture";
+  const allowModels = filter === "all" || filter === "model";
 
   const displayName = asset.displayName || asset.assetId;
   const description = normalizeDescription(asset);
 
-  for (const preview of extractMapPreviews(asset)) {
-    const mapLabel = preview.name.trim().replace(/\s+/g, " ");
-    const id = `ambientcg:${asset.assetId}:preview:${slugify(mapLabel) || slugify(preview.url)}`;
-    textures.push({
-      id,
-      label: `${displayName} • ${mapLabel}`,
-      type: "texture",
-      source: preview.url,
-      description,
-      tags: buildTags(asset, [mapLabel, "preview"]),
-      builtin: true,
-      preview: preview.url,
-      provider,
-    });
+  if (allowTextures) {
+    for (const preview of extractMapPreviews(asset)) {
+      const mapLabel = preview.name.trim().replace(/\s+/g, " ");
+      const id = `ambientcg:${asset.assetId}:preview:${slugify(mapLabel) || slugify(preview.url)}`;
+      items.push({
+        id,
+        label: `${displayName} • ${mapLabel}`,
+        type: "texture",
+        source: preview.url,
+        description,
+        tags: buildTags(asset, [mapLabel, "preview"]),
+        builtin: true,
+        preview: preview.url,
+        provider,
+      });
+    }
+
+    for (const hdri of extractHdriPreviews(asset)) {
+      const name = hdri.name || "Preview";
+      const id = `ambientcg:${asset.assetId}:hdri:${slugify(name)}:${slugify(hdri.url)}`;
+      items.push({
+        id,
+        label: `${displayName} • ${name}`,
+        type: "texture",
+        source: hdri.url,
+        description,
+        tags: buildTags(asset, [name, "preview"]),
+        builtin: true,
+        preview: previewImage ?? hdri.url,
+        provider,
+      });
+    }
+
+    for (const download of extractDirectDownloads(asset)) {
+      const link = download.downloadLink || download.fullDownloadPath;
+      if (!link) continue;
+      const attribute = download.attribute || download.fileName || download.filetype || "Variant";
+      const labelAttribute = attribute.replace(/[-_]+/g, " ");
+      const id = `ambientcg:${asset.assetId}:direct:${slugify(attribute)}:${slugify(link)}`;
+      items.push({
+        id,
+        label: `${displayName} • ${labelAttribute}`,
+        type: "texture",
+        source: link,
+        description,
+        tags: buildTags(asset, [attribute, download.filetype ?? ""]),
+        builtin: true,
+        preview: previewImage,
+        provider,
+      });
+    }
   }
 
-  for (const hdri of extractHdriPreviews(asset)) {
-    const name = hdri.name || "Preview";
-    const id = `ambientcg:${asset.assetId}:hdri:${slugify(name)}:${slugify(hdri.url)}`;
-    textures.push({
-      id,
-      label: `${displayName} • ${name}`,
-      type: "texture",
-      source: hdri.url,
-      description,
-      tags: buildTags(asset, [name, "preview"]),
-      builtin: true,
-      preview: previewImage ?? hdri.url,
-      provider,
-    });
+  if (allowModels) {
+    for (const selection of selectModelDownloads(asset)) {
+      const download = selection.download;
+      const link = download.downloadLink || download.fullDownloadPath;
+      if (!link) continue;
+      const file = selection.filename;
+      const ext = file.split(".").pop()?.toLowerCase() ?? "";
+      const id = `ambientcg:${asset.assetId}:model:${slugify(file)}`;
+      const attribute = download.attribute?.replace(/[-_]+/g, " ") || ext.toUpperCase();
+      const source = buildAmbientcgFileUrl(link, file);
+      items.push({
+        id,
+        label: `${displayName} • ${attribute}`,
+        type: "model",
+        source,
+        description,
+        tags: buildTags(asset, [attribute, ext]),
+        builtin: true,
+        preview: previewImage,
+        provider,
+      });
+    }
   }
 
-  for (const download of extractDirectDownloads(asset)) {
-    const link = download.downloadLink || download.fullDownloadPath;
-    if (!link) continue;
-    const attribute = download.attribute || download.fileName || download.filetype || "Variant";
-    const labelAttribute = attribute.replace(/[-_]+/g, " ");
-    const id = `ambientcg:${asset.assetId}:direct:${slugify(attribute)}:${slugify(link)}`;
-    textures.push({
-      id,
-      label: `${displayName} • ${labelAttribute}`,
-      type: "texture",
-      source: link,
-      description,
-      tags: buildTags(asset, [attribute, download.filetype ?? ""]),
-      builtin: true,
-      preview: previewImage,
-      provider,
-    });
-  }
-
-  for (const selection of selectModelDownloads(asset)) {
-    const download = selection.download;
-    const link = download.downloadLink || download.fullDownloadPath;
-    if (!link) continue;
-    const file = selection.filename;
-    const ext = file.split(".").pop()?.toLowerCase() ?? "";
-    const id = `ambientcg:${asset.assetId}:model:${slugify(file)}`;
-    const attribute = download.attribute?.replace(/[-_]+/g, " ") || ext.toUpperCase();
-    const source = buildAmbientcgFileUrl(link, file);
-    models.push({
-      id,
-      label: `${displayName} • ${attribute}`,
-      type: "model",
-      source,
-      description,
-      tags: buildTags(asset, [attribute, ext]),
-      builtin: true,
-      preview: previewImage,
-      provider,
-    });
-  }
-
-  return { textures, models };
+  return items;
 }
 
 function buildAmbientcgFileUrl(downloadLink: string, fileName: string): string {
@@ -357,11 +353,31 @@ function buildAmbientcgFileUrl(downloadLink: string, fileName: string): string {
   return `/api/assets/ambientcg/file?${params.toString()}`;
 }
 
-async function fetchAmbientcgPage(offset: number): Promise<AmbientcgApiResponse> {
+function parseOffsetFromUrl(url: string | null | undefined): number | null {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    const offsetParam = parsed.searchParams.get("offset");
+    if (!offsetParam) return null;
+    const offset = Number(offsetParam);
+    return Number.isFinite(offset) ? offset : null;
+  } catch (_err) {
+    return null;
+  }
+}
+
+function makePageCacheKey(query: string, offset: number): string {
+  return `${query.toLowerCase()}::${offset}`;
+}
+
+async function fetchAmbientcgPageRaw(query: string, offset: number): Promise<AmbientcgApiResponse> {
   const url = new URL(API_BASE_URL);
   url.searchParams.set("limit", String(PAGE_SIZE));
-  url.searchParams.set("offset", String(offset));
+  url.searchParams.set("offset", String(Math.max(0, offset)));
   url.searchParams.set("include", API_INCLUDE);
+  if (query) {
+    url.searchParams.set("q", query);
+  }
   const res = await fetch(url.toString(), { headers: { accept: "application/json" } });
   if (!res.ok) {
     throw new Error(`ambientCG API error: ${res.status}`);
@@ -369,80 +385,96 @@ async function fetchAmbientcgPage(offset: number): Promise<AmbientcgApiResponse>
   return (await res.json()) as AmbientcgApiResponse;
 }
 
-async function fetchAmbientcgAssets(): Promise<AmbientcgAsset[]> {
-  const assets: AmbientcgAsset[] = [];
-  let offset = 0;
-  let safety = 0;
-  const maxPages = 64;
-  while (safety < maxPages) {
-    safety += 1;
-    const page = await fetchAmbientcgPage(offset);
-    const found = Array.isArray(page.foundAssets) ? page.foundAssets : [];
-    assets.push(...found);
-    if (!page.nextPageHttp || found.length === 0) break;
-    offset += PAGE_SIZE;
-    if (typeof page.numberOfResults === "number" && offset >= page.numberOfResults) break;
+async function loadAmbientcgPage(query: string, offset: number): Promise<AmbientcgPageCacheEntry> {
+  const key = makePageCacheKey(query, offset);
+  const now = Date.now();
+  const cached = pageCache.get(key);
+  if (cached && cached.expiresAt > now) {
+    return cached;
   }
-  return assets;
+  const response = await fetchAmbientcgPageRaw(query, offset);
+  const assets = Array.isArray(response.foundAssets) ? response.foundAssets : [];
+  const nextOffset = parseOffsetFromUrl(response.nextPageHttp);
+  const entry: AmbientcgPageCacheEntry = {
+    assets,
+    nextOffset,
+    expiresAt: now + PAGE_CACHE_TTL_MS,
+  };
+  pageCache.set(key, entry);
+  return entry;
 }
 
-async function buildAmbientcgLibrary(): Promise<AmbientcgLibrary> {
-  const assets = await fetchAmbientcgAssets();
-  const textures: AssetItem[] = [];
-  const models: AssetItem[] = [];
-  for (const asset of assets) {
-    if (!asset?.assetId) continue;
-    const mapped = mapAsset(asset);
-    textures.push(...mapped.textures);
-    models.push(...mapped.models);
+function parseCursor(cursor: string | null | undefined): number {
+  if (!cursor) return 0;
+  const value = Number(cursor);
+  if (!Number.isFinite(value) || value < 0) return 0;
+  return Math.floor(value);
+}
+
+function encodeCursor(offset: number | null): string | null {
+  if (offset === null || !Number.isFinite(offset) || offset < 0) return null;
+  return String(Math.floor(offset));
+}
+
+export type AmbientcgCatalogQuery = {
+  cursor?: string | null;
+  query?: string;
+  type?: "texture" | "model" | "all";
+};
+
+export type AmbientcgCatalogResult = {
+  items: AssetItem[];
+  cursor: string | null;
+};
+
+export async function queryAmbientcgItems(options: AmbientcgCatalogQuery = {}): Promise<AmbientcgCatalogResult> {
+  const query = (options.query ?? "").trim();
+  const filter: AmbientcgItemType = options.type === "texture" || options.type === "model" ? options.type : "all";
+  let offset = parseCursor(options.cursor);
+  let page = await loadAmbientcgPage(query, offset);
+  let nextOffset = page.nextOffset;
+
+  const items: AssetItem[] = [];
+  const maxPages = filter === "all" ? 1 : 4;
+  const minResults = filter === "model" ? 8 : filter === "texture" ? 24 : 0;
+  let processed = 0;
+
+  while (true) {
+    processed += 1;
+    for (const asset of page.assets) {
+      if (!asset?.assetId) continue;
+      items.push(...mapAmbientcgAsset(asset, filter));
+    }
+
+    if (filter === "all") break;
+    if (items.length >= minResults) break;
+    if (nextOffset === null) break;
+    if (processed >= maxPages) break;
+
+    offset = nextOffset;
+    page = await loadAmbientcgPage(query, offset);
+    nextOffset = page.nextOffset;
   }
+
   return {
-    textures,
-    models,
+    items,
+    cursor: encodeCursor(nextOffset),
   };
 }
 
-export async function loadAmbientcgLibrary(): Promise<AmbientcgLibrary> {
-  const now = Date.now();
-  if (libraryCache.value && libraryCache.expiresAt > now) {
-    return libraryCache.value;
+export async function ambientcgCatalogHandler(req: Request): Promise<Response> {
+  try {
+    const url = new URL(req.url);
+    const cursor = url.searchParams.get("cursor");
+    const query = url.searchParams.get("query") ?? "";
+    const typeParam = (url.searchParams.get("type") ?? "").toLowerCase();
+    const type = typeParam === "texture" || typeParam === "model" ? typeParam : typeParam === "all" ? "all" : undefined;
+    const result = await queryAmbientcgItems({ cursor, query, type });
+    return Response.json(result);
+  } catch (err) {
+    console.error("[ambientcg] catalog handler failed", err);
+    return Response.json({ error: "Failed to load ambientCG assets" }, { status: 500 });
   }
-  if (libraryCache.promise) {
-    return libraryCache.promise;
-  }
-  const promise = buildAmbientcgLibrary()
-    .then((library) => {
-      libraryCache.value = library;
-      libraryCache.expiresAt = Date.now() + LIBRARY_CACHE_TTL_MS;
-      libraryCache.promise = null;
-      return library;
-    })
-    .catch((err) => {
-      libraryCache.promise = null;
-      throw err;
-    });
-  libraryCache.promise = promise;
-  return promise;
-}
-
-export async function loadAmbientcgCategories(): Promise<AssetCategory[]> {
-  const library = await loadAmbientcgLibrary();
-  const categories: AssetCategory[] = [];
-  if (library.textures.length) {
-    categories.push({
-      id: "ambientcg:textures",
-      label: "ambientCG • Textures",
-      items: library.textures,
-    });
-  }
-  if (library.models.length) {
-    categories.push({
-      id: "ambientcg:models",
-      label: "ambientCG • Models",
-      items: library.models,
-    });
-  }
-  return categories;
 }
 
 export async function ambientcgFileHandler(req: Request): Promise<Response> {

--- a/src/server/providers/ambientcg.ts
+++ b/src/server/providers/ambientcg.ts
@@ -10,7 +10,6 @@ const PAGE_SIZE = 96;
 const PAGE_CACHE_TTL_MS = 30 * 60 * 1000;
 const ZIP_CACHE_TTL_MS = 10 * 60 * 1000;
 
-const MODEL_FILE_EXTENSIONS = new Set(["usdc", "usd", "usdz", "glb", "gltf", "obj", "fbx"]);
 const DIRECT_FILE_EXTENSIONS = new Set(["exr", "hdr", "png", "jpg", "jpeg", "webp", "tif", "tiff"]);
 
 const MIME_BY_EXTENSION: Record<string, string> = {
@@ -218,37 +217,6 @@ function extractDirectDownloads(asset: AmbientcgAsset): AmbientcgDownload[] {
   return downloads;
 }
 
-function selectModelDownloads(asset: AmbientcgAsset): Array<{ download: AmbientcgDownload; filename: string }> {
-  const folders = asset.downloadFolders?.default?.downloadFiletypeCategories;
-  if (!folders) return [];
-  const selections: Array<{ download: AmbientcgDownload; filename: string }> = [];
-  for (const category of Object.values(folders)) {
-    if (!category?.downloads) continue;
-    const sorted = [...category.downloads].sort((a, b) => {
-      const weight = (value: string | undefined) => {
-        if (!value) return Number.POSITIVE_INFINITY;
-        const match = value.match(/(\d+)(k|m)/i);
-        if (!match) return Number.POSITIVE_INFINITY;
-        const amount = Number(match[1]);
-        const unit = match[2].toLowerCase();
-        return unit === "m" ? amount * 1000 : amount;
-      };
-      return weight(a.attribute) - weight(b.attribute);
-    });
-    for (const download of sorted) {
-      const contents = download?.zipContent ?? [];
-      for (const file of contents) {
-        const ext = file.split(".").pop()?.toLowerCase() ?? "";
-        if (!MODEL_FILE_EXTENSIONS.has(ext)) continue;
-        selections.push({ download, filename: file });
-        break;
-      }
-      if (selections.length) break;
-    }
-  }
-  return selections;
-}
-
 type AmbientcgItemType = "all" | "texture" | "model";
 
 function mapAmbientcgAsset(asset: AmbientcgAsset, filter: AmbientcgItemType): AssetItem[] {
@@ -260,8 +228,10 @@ function mapAmbientcgAsset(asset: AmbientcgAsset, filter: AmbientcgItemType): As
   } as const;
   const previewImage = pickPreviewImage(asset.previewImage);
   const items: AssetItem[] = [];
+  if (filter === "model") {
+    return items;
+  }
   const allowTextures = filter === "all" || filter === "texture";
-  const allowModels = filter === "all" || filter === "model";
 
   const displayName = asset.displayName || asset.assetId;
   const description = normalizeDescription(asset);
@@ -319,38 +289,7 @@ function mapAmbientcgAsset(asset: AmbientcgAsset, filter: AmbientcgItemType): As
     }
   }
 
-  if (allowModels) {
-    for (const selection of selectModelDownloads(asset)) {
-      const download = selection.download;
-      const link = download.downloadLink || download.fullDownloadPath;
-      if (!link) continue;
-      const file = selection.filename;
-      const ext = file.split(".").pop()?.toLowerCase() ?? "";
-      const id = `ambientcg:${asset.assetId}:model:${slugify(file)}`;
-      const attribute = download.attribute?.replace(/[-_]+/g, " ") || ext.toUpperCase();
-      const source = buildAmbientcgFileUrl(link, file);
-      items.push({
-        id,
-        label: `${displayName} • ${attribute}`,
-        type: "model",
-        source,
-        description,
-        tags: buildTags(asset, [attribute, ext]),
-        builtin: true,
-        preview: previewImage,
-        provider,
-      });
-    }
-  }
-
   return items;
-}
-
-function buildAmbientcgFileUrl(downloadLink: string, fileName: string): string {
-  const params = new URLSearchParams();
-  params.set("download", downloadLink);
-  params.set("file", fileName);
-  return `/api/assets/ambientcg/file?${params.toString()}`;
 }
 
 function parseOffsetFromUrl(url: string | null | undefined): number | null {
@@ -430,13 +369,16 @@ export type AmbientcgCatalogResult = {
 export async function queryAmbientcgItems(options: AmbientcgCatalogQuery = {}): Promise<AmbientcgCatalogResult> {
   const query = (options.query ?? "").trim();
   const filter: AmbientcgItemType = options.type === "texture" || options.type === "model" ? options.type : "all";
+  if (filter === "model") {
+    return { items: [], cursor: null };
+  }
   let offset = parseCursor(options.cursor);
   let page = await loadAmbientcgPage(query, offset);
   let nextOffset = page.nextOffset;
 
   const items: AssetItem[] = [];
   const maxPages = filter === "all" ? 1 : 4;
-  const minResults = filter === "model" ? 8 : filter === "texture" ? 24 : 0;
+  const minResults = filter === "texture" ? 24 : 0;
   let processed = 0;
 
   while (true) {

--- a/src/server/providers/ambientcg.ts
+++ b/src/server/providers/ambientcg.ts
@@ -1,0 +1,497 @@
+import { unzipSync } from "fflate";
+import type { AssetCategory, AssetItem } from "../../core/schema/types";
+
+export const AMBIENT_CG_PROVIDER_ID = "ambientcg";
+export const AMBIENT_CG_PROVIDER_NAME = "ambientCG";
+
+const API_BASE_URL = "https://ambientcg.com/api/v2/full_json";
+const API_INCLUDE = "downloadData,mapData,previewData";
+const PAGE_SIZE = 128;
+const LIBRARY_CACHE_TTL_MS = 30 * 60 * 1000;
+const ZIP_CACHE_TTL_MS = 10 * 60 * 1000;
+
+const MODEL_FILE_EXTENSIONS = new Set(["usdc", "usd", "usdz", "glb", "gltf", "obj", "fbx"]);
+const DIRECT_FILE_EXTENSIONS = new Set(["exr", "hdr", "png", "jpg", "jpeg", "webp", "tif", "tiff"]);
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  exr: "image/exr",
+  hdr: "image/vnd.radiance",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  webp: "image/webp",
+  tif: "image/tiff",
+  tiff: "image/tiff",
+  usdc: "application/octet-stream",
+  usd: "application/octet-stream",
+  usdz: "model/vnd.usdz+zip",
+  glb: "model/gltf-binary",
+  gltf: "model/gltf+json",
+  obj: "text/plain",
+  fbx: "application/octet-stream",
+};
+
+type AmbientcgPreviewLink = {
+  url?: string;
+  name?: {
+    slug?: string;
+    title?: string;
+  } | null;
+};
+
+type AmbientcgDownload = {
+  downloadLink?: string;
+  fullDownloadPath?: string;
+  fileName?: string;
+  filetype?: string;
+  attribute?: string;
+  zipContent?: string[];
+};
+
+type AmbientcgAsset = {
+  assetId: string;
+  displayName?: string;
+  dataType?: string;
+  description?: string;
+  displayCategory?: string;
+  tags?: string[];
+  shortLink?: string;
+  previewLinks?: AmbientcgPreviewLink[];
+  previewImage?: Record<string, string>;
+  downloadFolders?: {
+    default?: {
+      downloadFiletypeCategories?: Record<string, { downloads?: AmbientcgDownload[] }>;
+    };
+  };
+};
+
+type AmbientcgApiResponse = {
+  foundAssets?: AmbientcgAsset[];
+  nextPageHttp?: string | null;
+  numberOfResults?: number;
+};
+
+type AmbientcgLibrary = {
+  textures: AssetItem[];
+  models: AssetItem[];
+};
+
+type LibraryCacheState = {
+  expiresAt: number;
+  value: AmbientcgLibrary | null;
+  promise: Promise<AmbientcgLibrary> | null;
+};
+
+type ZipCacheEntry = {
+  expiresAt: number;
+  data: Uint8Array;
+  contentType: string;
+  filename: string;
+};
+
+const libraryCache: LibraryCacheState = {
+  expiresAt: 0,
+  value: null,
+  promise: null,
+};
+
+const zipCache = new Map<string, ZipCacheEntry>();
+
+function slugify(value: string | undefined | null): string {
+  if (!value) return "";
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 120);
+}
+
+function pickPreviewImage(previewImage?: Record<string, string>): string | undefined {
+  if (!previewImage) return undefined;
+  const preferredOrder = [
+    "1024-PNG",
+    "1024-JPG-242424",
+    "512-PNG",
+    "512-JPG-242424",
+    "256-PNG",
+    "256-JPG-242424",
+  ];
+  for (const key of preferredOrder) {
+    if (previewImage[key]) return previewImage[key];
+  }
+  const first = Object.values(previewImage)[0];
+  return typeof first === "string" ? first : undefined;
+}
+
+function normalizeDescription(asset: AmbientcgAsset): string {
+  return asset.description || asset.displayCategory || "";
+}
+
+function buildTags(asset: AmbientcgAsset, extra?: string[]): string[] {
+  const tags: string[] = [];
+  if (asset.dataType) tags.push(asset.dataType.toLowerCase());
+  if (Array.isArray(asset.tags)) {
+    for (const tag of asset.tags) {
+      if (typeof tag === "string" && tag.trim()) tags.push(tag.trim().toLowerCase());
+    }
+  }
+  for (const item of extra ?? []) {
+    if (item && item.trim()) tags.push(item.trim().toLowerCase());
+  }
+  tags.push(AMBIENT_CG_PROVIDER_ID);
+  return Array.from(new Set(tags));
+}
+
+function parsePreviewList(link: string | undefined): string[] {
+  if (!link) return [];
+  const hashIndex = link.indexOf("#");
+  if (hashIndex === -1) return [];
+  const fragment = link.slice(hashIndex + 1);
+  const params = new URLSearchParams(fragment);
+  const raw = params.get("texture_url") ?? params.get("environment_url");
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function parsePreviewNames(link: string | undefined): string[] {
+  if (!link) return [];
+  const hashIndex = link.indexOf("#");
+  if (hashIndex === -1) return [];
+  const fragment = link.slice(hashIndex + 1);
+  const params = new URLSearchParams(fragment);
+  const raw = params.get("texture_name") ?? params.get("environment_name");
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function extractMapPreviews(asset: AmbientcgAsset): Array<{ name: string; url: string }> {
+  const previews: Array<{ name: string; url: string }> = [];
+  const entries = asset.previewLinks ?? [];
+  for (const entry of entries) {
+    const slug = entry?.name?.slug ?? entry?.name?.title ?? "";
+    if (!slug) continue;
+    const normalizedSlug = slug.toLowerCase();
+    if (!normalizedSlug.includes("material") && !normalizedSlug.includes("texture")) continue;
+    const urls = parsePreviewList(entry.url);
+    const names = parsePreviewNames(entry.url);
+    for (let index = 0; index < urls.length; index += 1) {
+      const url = urls[index];
+      if (!url) continue;
+      const name = names[index] ?? `Map ${index + 1}`;
+      previews.push({ name, url });
+    }
+    if (previews.length) break;
+  }
+  return previews;
+}
+
+function extractHdriPreviews(asset: AmbientcgAsset): Array<{ name: string; url: string }> {
+  const previews: Array<{ name: string; url: string }> = [];
+  const entries = asset.previewLinks ?? [];
+  for (const entry of entries) {
+    const slug = entry?.name?.slug ?? entry?.name?.title ?? "";
+    if (!slug) continue;
+    const normalizedSlug = slug.toLowerCase();
+    if (!normalizedSlug.includes("panorama")) continue;
+    const urls = parsePreviewList(entry.url);
+    const names = parsePreviewNames(entry.url);
+    for (let index = 0; index < urls.length; index += 1) {
+      const url = urls[index];
+      if (!url) continue;
+      const name = names[index] ?? `Preview ${index + 1}`;
+      previews.push({ name, url });
+    }
+    if (previews.length) break;
+  }
+  return previews;
+}
+
+function extractDirectDownloads(asset: AmbientcgAsset): AmbientcgDownload[] {
+  const folders = asset.downloadFolders?.default?.downloadFiletypeCategories;
+  if (!folders) return [];
+  const downloads: AmbientcgDownload[] = [];
+  for (const category of Object.values(folders)) {
+    if (!category?.downloads) continue;
+    for (const download of category.downloads) {
+      const ext = (download?.filetype ?? "").toLowerCase();
+      const hasZip = Array.isArray(download?.zipContent) && download!.zipContent!.length > 0;
+      if (hasZip) continue;
+      if (!DIRECT_FILE_EXTENSIONS.has(ext)) continue;
+      downloads.push(download);
+    }
+  }
+  return downloads;
+}
+
+function selectModelDownloads(asset: AmbientcgAsset): Array<{ download: AmbientcgDownload; filename: string }> {
+  const folders = asset.downloadFolders?.default?.downloadFiletypeCategories;
+  if (!folders) return [];
+  const selections: Array<{ download: AmbientcgDownload; filename: string }> = [];
+  for (const category of Object.values(folders)) {
+    if (!category?.downloads) continue;
+    const sorted = [...category.downloads].sort((a, b) => {
+      const weight = (value: string | undefined) => {
+        if (!value) return Number.POSITIVE_INFINITY;
+        const match = value.match(/(\d+)(k|m)/i);
+        if (!match) return Number.POSITIVE_INFINITY;
+        const amount = Number(match[1]);
+        const unit = match[2].toLowerCase();
+        return unit === "m" ? amount * 1000 : amount;
+      };
+      return weight(a.attribute) - weight(b.attribute);
+    });
+    for (const download of sorted) {
+      const contents = download?.zipContent ?? [];
+      for (const file of contents) {
+        const ext = file.split(".").pop()?.toLowerCase() ?? "";
+        if (!MODEL_FILE_EXTENSIONS.has(ext)) continue;
+        selections.push({ download, filename: file });
+        break;
+      }
+      if (selections.length) break;
+    }
+  }
+  return selections;
+}
+
+function mapAsset(asset: AmbientcgAsset): AmbientcgLibrary {
+  const provider = {
+    id: AMBIENT_CG_PROVIDER_ID,
+    name: AMBIENT_CG_PROVIDER_NAME,
+    assetId: asset.assetId,
+    assetUrl: asset.shortLink,
+  };
+  const previewImage = pickPreviewImage(asset.previewImage);
+  const textures: AssetItem[] = [];
+  const models: AssetItem[] = [];
+
+  const displayName = asset.displayName || asset.assetId;
+  const description = normalizeDescription(asset);
+
+  for (const preview of extractMapPreviews(asset)) {
+    const mapLabel = preview.name.trim().replace(/\s+/g, " ");
+    const id = `ambientcg:${asset.assetId}:preview:${slugify(mapLabel) || slugify(preview.url)}`;
+    textures.push({
+      id,
+      label: `${displayName} • ${mapLabel}`,
+      type: "texture",
+      source: preview.url,
+      description,
+      tags: buildTags(asset, [mapLabel, "preview"]),
+      builtin: true,
+      preview: preview.url,
+      provider,
+    });
+  }
+
+  for (const hdri of extractHdriPreviews(asset)) {
+    const name = hdri.name || "Preview";
+    const id = `ambientcg:${asset.assetId}:hdri:${slugify(name)}:${slugify(hdri.url)}`;
+    textures.push({
+      id,
+      label: `${displayName} • ${name}`,
+      type: "texture",
+      source: hdri.url,
+      description,
+      tags: buildTags(asset, [name, "preview"]),
+      builtin: true,
+      preview: previewImage ?? hdri.url,
+      provider,
+    });
+  }
+
+  for (const download of extractDirectDownloads(asset)) {
+    const link = download.downloadLink || download.fullDownloadPath;
+    if (!link) continue;
+    const attribute = download.attribute || download.fileName || download.filetype || "Variant";
+    const labelAttribute = attribute.replace(/[-_]+/g, " ");
+    const id = `ambientcg:${asset.assetId}:direct:${slugify(attribute)}:${slugify(link)}`;
+    textures.push({
+      id,
+      label: `${displayName} • ${labelAttribute}`,
+      type: "texture",
+      source: link,
+      description,
+      tags: buildTags(asset, [attribute, download.filetype ?? ""]),
+      builtin: true,
+      preview: previewImage,
+      provider,
+    });
+  }
+
+  for (const selection of selectModelDownloads(asset)) {
+    const download = selection.download;
+    const link = download.downloadLink || download.fullDownloadPath;
+    if (!link) continue;
+    const file = selection.filename;
+    const ext = file.split(".").pop()?.toLowerCase() ?? "";
+    const id = `ambientcg:${asset.assetId}:model:${slugify(file)}`;
+    const attribute = download.attribute?.replace(/[-_]+/g, " ") || ext.toUpperCase();
+    const source = buildAmbientcgFileUrl(link, file);
+    models.push({
+      id,
+      label: `${displayName} • ${attribute}`,
+      type: "model",
+      source,
+      description,
+      tags: buildTags(asset, [attribute, ext]),
+      builtin: true,
+      preview: previewImage,
+      provider,
+    });
+  }
+
+  return { textures, models };
+}
+
+function buildAmbientcgFileUrl(downloadLink: string, fileName: string): string {
+  const params = new URLSearchParams();
+  params.set("download", downloadLink);
+  params.set("file", fileName);
+  return `/api/assets/ambientcg/file?${params.toString()}`;
+}
+
+async function fetchAmbientcgPage(offset: number): Promise<AmbientcgApiResponse> {
+  const url = new URL(API_BASE_URL);
+  url.searchParams.set("limit", String(PAGE_SIZE));
+  url.searchParams.set("offset", String(offset));
+  url.searchParams.set("include", API_INCLUDE);
+  const res = await fetch(url.toString(), { headers: { accept: "application/json" } });
+  if (!res.ok) {
+    throw new Error(`ambientCG API error: ${res.status}`);
+  }
+  return (await res.json()) as AmbientcgApiResponse;
+}
+
+async function fetchAmbientcgAssets(): Promise<AmbientcgAsset[]> {
+  const assets: AmbientcgAsset[] = [];
+  let offset = 0;
+  let safety = 0;
+  const maxPages = 64;
+  while (safety < maxPages) {
+    safety += 1;
+    const page = await fetchAmbientcgPage(offset);
+    const found = Array.isArray(page.foundAssets) ? page.foundAssets : [];
+    assets.push(...found);
+    if (!page.nextPageHttp || found.length === 0) break;
+    offset += PAGE_SIZE;
+    if (typeof page.numberOfResults === "number" && offset >= page.numberOfResults) break;
+  }
+  return assets;
+}
+
+async function buildAmbientcgLibrary(): Promise<AmbientcgLibrary> {
+  const assets = await fetchAmbientcgAssets();
+  const textures: AssetItem[] = [];
+  const models: AssetItem[] = [];
+  for (const asset of assets) {
+    if (!asset?.assetId) continue;
+    const mapped = mapAsset(asset);
+    textures.push(...mapped.textures);
+    models.push(...mapped.models);
+  }
+  return {
+    textures,
+    models,
+  };
+}
+
+export async function loadAmbientcgLibrary(): Promise<AmbientcgLibrary> {
+  const now = Date.now();
+  if (libraryCache.value && libraryCache.expiresAt > now) {
+    return libraryCache.value;
+  }
+  if (libraryCache.promise) {
+    return libraryCache.promise;
+  }
+  const promise = buildAmbientcgLibrary()
+    .then((library) => {
+      libraryCache.value = library;
+      libraryCache.expiresAt = Date.now() + LIBRARY_CACHE_TTL_MS;
+      libraryCache.promise = null;
+      return library;
+    })
+    .catch((err) => {
+      libraryCache.promise = null;
+      throw err;
+    });
+  libraryCache.promise = promise;
+  return promise;
+}
+
+export async function loadAmbientcgCategories(): Promise<AssetCategory[]> {
+  const library = await loadAmbientcgLibrary();
+  const categories: AssetCategory[] = [];
+  if (library.textures.length) {
+    categories.push({
+      id: "ambientcg:textures",
+      label: "ambientCG • Textures",
+      items: library.textures,
+    });
+  }
+  if (library.models.length) {
+    categories.push({
+      id: "ambientcg:models",
+      label: "ambientCG • Models",
+      items: library.models,
+    });
+  }
+  return categories;
+}
+
+export async function ambientcgFileHandler(req: Request): Promise<Response> {
+  try {
+    const url = new URL(req.url);
+    const download = url.searchParams.get("download");
+    const file = url.searchParams.get("file");
+    if (!download || !file) {
+      return Response.json({ error: "Missing 'download' or 'file' parameters" }, { status: 400 });
+    }
+    const cacheKey = `${download}::${file}`;
+    const now = Date.now();
+    const cached = zipCache.get(cacheKey);
+    if (cached && cached.expiresAt > now) {
+      const payload = cached.data.slice().buffer;
+      return new Response(payload, {
+        headers: {
+          "content-type": cached.contentType,
+          "cache-control": "public, max-age=300",
+          "x-ambientcg-filename": cached.filename,
+        },
+      });
+    }
+    const res = await fetch(download, { headers: { accept: "application/zip" } });
+    if (!res.ok) {
+      return Response.json({ error: `Failed to fetch ambientCG archive: ${res.status}` }, { status: 502 });
+    }
+    const arrayBuffer = await res.arrayBuffer();
+    const buffer = new Uint8Array(arrayBuffer);
+    const zipEntries = unzipSync(buffer);
+    const entryName = Object.keys(zipEntries).find((name) => name.toLowerCase() === file.toLowerCase());
+    if (!entryName) {
+      return Response.json({ error: `File '${file}' not found in archive` }, { status: 404 });
+    }
+    const data = zipEntries[entryName];
+    const ext = entryName.split(".").pop()?.toLowerCase() ?? "";
+    const contentType = MIME_BY_EXTENSION[ext] ?? "application/octet-stream";
+    const expiresAt = Date.now() + ZIP_CACHE_TTL_MS;
+    zipCache.set(cacheKey, { data, contentType, expiresAt, filename: entryName });
+    const payload = data.slice().buffer;
+    return new Response(payload, {
+      headers: {
+        "content-type": contentType,
+        "cache-control": "public, max-age=300",
+        "x-ambientcg-filename": entryName,
+      },
+    });
+  } catch (err) {
+    console.error("[ambientcg] file handler failed", err);
+    return Response.json({ error: "Failed to fetch file" }, { status: 500 });
+  }
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1,7 +1,7 @@
 import { languagesHandler, languagePackHandler, compileHandler } from "./handlers";
 import { nodesListHandler, nodeTemplateHandler } from "./nodes";
 import { assetsHandler } from "./assets";
-import { ambientcgFileHandler } from "./providers/ambientcg";
+import { ambientcgCatalogHandler, ambientcgFileHandler } from "./providers/ambientcg";
 import { examplesHandler } from "./examples";
 
 export function buildRoutes() {
@@ -306,6 +306,7 @@ export function buildRoutes() {
     "/api/nodes": nodesListHandler,
     "/api/node-template": nodeTemplateHandler,
     "/api/assets": assetsHandler,
+    "/api/assets/ambientcg/catalog": ambientcgCatalogHandler,
     "/api/assets/ambientcg/file": ambientcgFileHandler,
     "/api/languages": languagesHandler,
     "/api/language": languagePackHandler,

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1,6 +1,7 @@
 import { languagesHandler, languagePackHandler, compileHandler } from "./handlers";
 import { nodesListHandler, nodeTemplateHandler } from "./nodes";
 import { assetsHandler } from "./assets";
+import { ambientcgFileHandler } from "./providers/ambientcg";
 import { examplesHandler } from "./examples";
 
 export function buildRoutes() {
@@ -305,6 +306,7 @@ export function buildRoutes() {
     "/api/nodes": nodesListHandler,
     "/api/node-template": nodeTemplateHandler,
     "/api/assets": assetsHandler,
+    "/api/assets/ambientcg/file": ambientcgFileHandler,
     "/api/languages": languagesHandler,
     "/api/language": languagePackHandler,
     "/api/compile": { async POST(req: Request) { return compileHandler(req); } },

--- a/src/ui/settings/SettingsPage.tsx
+++ b/src/ui/settings/SettingsPage.tsx
@@ -5,9 +5,19 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { formatQuickHotkeyDisplay, type QuickNodeHotkey } from "@/core/ui/hotkeys";
-import type { NodePalette, NodePaletteItem } from "@/core/schema/types";
+import type { AssetItem, NodePalette, NodePaletteItem } from "@/core/schema/types";
 import type { AssetLibrariesSettings, CurveMode, ThemeName } from "@/ui/state/SettingsContext";
+import { Plus, Trash2 } from "lucide-react";
+import {
+  appendUserAsset,
+  createUserAssetId,
+  loadUserAssets,
+  removeUserAssetById,
+  saveUserAssets,
+  USER_ASSETS_CHANGED_EVENT,
+} from "@/core/assets/userAssets";
 
 type SettingsPageProps = {
   curveMode: CurveMode;
@@ -159,18 +169,127 @@ type AssetLibrariesCardProps = {
 
 function AssetLibrariesCard({ assetLibraries, onChange }: AssetLibrariesCardProps) {
   const ambientEnabled = assetLibraries?.ambientcg?.enabled ?? false;
+  const [manualAssets, setManualAssets] = useState<AssetItem[]>([]);
+  const [showManualForm, setShowManualForm] = useState(false);
+  const [manualUrl, setManualUrl] = useState("");
+  const [manualLabel, setManualLabel] = useState("");
+  const [manualType, setManualType] = useState<"texture" | "model">("texture");
+  const [manualError, setManualError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const stored = await loadUserAssets();
+        if (cancelled) return;
+        setManualAssets(stored);
+      } catch (err) {
+        console.warn("Failed to load saved assets", err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const listener = (event: Event) => {
+      const detail = (event as CustomEvent<AssetItem[]>).detail;
+      if (!Array.isArray(detail)) return;
+      setManualAssets(detail);
+    };
+    window.addEventListener(USER_ASSETS_CHANGED_EVENT, listener as EventListener);
+    return () => {
+      window.removeEventListener(USER_ASSETS_CHANGED_EVENT, listener as EventListener);
+    };
+  }, []);
+
+  const persistManualAssets = useCallback((updater: (prev: AssetItem[]) => AssetItem[]) => {
+    setManualAssets((prev) => {
+      const next = updater(prev);
+      void saveUserAssets(next).catch((err) => {
+        console.warn("Failed to persist manual assets", err);
+      });
+      return next;
+    });
+  }, []);
+
+  const toggleManualForm = useCallback(() => {
+    setShowManualForm((prev) => {
+      const next = !prev;
+      if (!next) {
+        setManualUrl("");
+        setManualLabel("");
+        setManualType("texture");
+        setManualError(null);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleManualSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const trimmedUrl = manualUrl.trim();
+      if (!trimmedUrl) {
+        setManualError("Enter a valid URL.");
+        return;
+      }
+      let normalizedUrl: string;
+      try {
+        const parsed = new URL(trimmedUrl);
+        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+          throw new Error("Unsupported protocol");
+        }
+        normalizedUrl = parsed.toString();
+      } catch {
+        setManualError("Enter a valid HTTP or HTTPS URL.");
+        return;
+      }
+      const label = manualLabel.trim() || normalizedUrl;
+      const type = manualType === "model" ? "model" : "texture";
+      const description =
+        type === "texture" ? "Manually added texture asset." : "Manually added model asset.";
+      const tags = ["user", type, "manual"];
+      const asset: AssetItem = {
+        id: createUserAssetId(),
+        label,
+        type,
+        source: normalizedUrl,
+        description,
+        tags,
+        builtin: false,
+        preview: type === "texture" ? normalizedUrl : undefined,
+      };
+      persistManualAssets((prev) => appendUserAsset(prev, asset));
+      setManualUrl("");
+      setManualLabel("");
+      setManualType("texture");
+      setManualError(null);
+    },
+    [manualLabel, manualType, manualUrl, persistManualAssets]
+  );
+
+  const handleManualRemove = useCallback(
+    (id: string) => {
+      persistManualAssets((prev) => removeUserAssetById(prev, id));
+    },
+    [persistManualAssets]
+  );
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>Asset Libraries</CardTitle>
-        <CardDescription>Connect external providers to expand the built-in asset catalog.</CardDescription>
+        <CardDescription>Connect external providers and save your own asset URLs for quick access.</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4 text-sm">
         <div className="flex flex-col gap-3 rounded-md border border-border/60 bg-muted/10 p-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-1">
             <div className="text-sm font-medium">ambientCG</div>
             <p className="text-xs text-muted-foreground">
-              Browse thousands of free PBR materials, HDRIs, and models hosted by ambientCG directly inside the Assets panel.
+              Browse thousands of free PBR materials and HDRI textures from ambientCG directly inside the Assets panel.
             </p>
           </div>
           <label className="flex items-center gap-2 text-xs font-medium">
@@ -186,9 +305,105 @@ function AssetLibrariesCard({ assetLibraries, onChange }: AssetLibrariesCardProp
             <span>{ambientEnabled ? "Enabled" : "Disabled"}</span>
           </label>
         </div>
+        <div className="space-y-3 rounded-md border border-border/60 bg-muted/10 p-4">
+          <div className="flex items-center justify-between gap-2">
+            <div className="space-y-1">
+              <div className="text-sm font-medium">Manual Asset URLs</div>
+              <p className="text-xs text-muted-foreground">
+                Store direct links to textures or models so they stay available in the My Assets section.
+              </p>
+            </div>
+            <Button
+              type="button"
+              size="icon"
+              variant="outline"
+              onClick={toggleManualForm}
+              aria-label={showManualForm ? "Hide manual asset form" : "Add manual asset"}
+            >
+              <Plus className="size-4" />
+            </Button>
+          </div>
+          {showManualForm ? (
+            <form className="space-y-3" onSubmit={handleManualSubmit}>
+              <div className="grid gap-3 sm:grid-cols-3">
+                <div className="space-y-1 sm:col-span-2">
+                  <Label htmlFor="manual-asset-url">Asset URL</Label>
+                  <Input
+                    id="manual-asset-url"
+                    type="url"
+                    value={manualUrl}
+                    onChange={(event) => setManualUrl(event.target.value)}
+                    placeholder="https://example.com/diffuse.png"
+                    required
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="manual-asset-type">Type</Label>
+                  <select
+                    id="manual-asset-type"
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    value={manualType}
+                    onChange={(event) => setManualType(event.target.value === "model" ? "model" : "texture")}
+                  >
+                    <option value="texture">Texture</option>
+                    <option value="model">Model</option>
+                  </select>
+                </div>
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="manual-asset-label">Display name (optional)</Label>
+                <Input
+                  id="manual-asset-label"
+                  value={manualLabel}
+                  onChange={(event) => setManualLabel(event.target.value)}
+                  placeholder="Wood Floor Albedo"
+                />
+              </div>
+              {manualError ? <p className="text-xs text-destructive">{manualError}</p> : null}
+              <div className="flex items-center gap-2">
+                <Button type="submit" size="sm">
+                  Save Asset
+                </Button>
+                <Button type="button" size="sm" variant="ghost" onClick={toggleManualForm}>
+                  Cancel
+                </Button>
+              </div>
+            </form>
+          ) : null}
+          {manualAssets.length > 0 ? (
+            <ul className="space-y-2">
+              {manualAssets.map((asset) => (
+                <li
+                  key={asset.id}
+                  className="flex items-center justify-between gap-3 rounded-md border border-border/60 bg-background/80 px-3 py-2 text-sm"
+                >
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">{asset.label}</div>
+                    <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                      {asset.type === "model" ? "Model" : "Texture"}
+                    </div>
+                  </div>
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    className="size-8"
+                    onClick={() => handleManualRemove(asset.id)}
+                    aria-label={`Remove ${asset.label}`}
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-[11px] leading-5 text-muted-foreground">
+              Saved assets appear in the Assets panel under My Assets for quick drag-and-drop access.
+            </p>
+          )}
+        </div>
         <p className="text-[11px] leading-5 text-muted-foreground">
-          When enabled, ambientCG assets appear alongside built-in textures and models. Assets load on demand and respect your
-          search and type filters.
+          ambientCG assets respect your search and type filters, and manual URLs stay synced with the My Assets collection.
         </p>
       </CardContent>
     </Card>

--- a/src/ui/settings/SettingsPage.tsx
+++ b/src/ui/settings/SettingsPage.tsx
@@ -7,7 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Button } from "@/components/ui/button";
 import { formatQuickHotkeyDisplay, type QuickNodeHotkey } from "@/core/ui/hotkeys";
 import type { NodePalette, NodePaletteItem } from "@/core/schema/types";
-import type { CurveMode, ThemeName } from "@/ui/state/SettingsContext";
+import type { AssetLibrariesSettings, CurveMode, ThemeName } from "@/ui/state/SettingsContext";
 
 type SettingsPageProps = {
   curveMode: CurveMode;
@@ -17,6 +17,10 @@ type SettingsPageProps = {
   quickHotkeys: QuickNodeHotkey[];
   onQuickHotkeysChange: (next: QuickNodeHotkey[]) => void;
   palette: NodePalette | null;
+  assetLibraries: AssetLibrariesSettings;
+  onAssetLibrariesChange: (
+    next: AssetLibrariesSettings | ((prev: AssetLibrariesSettings) => AssetLibrariesSettings)
+  ) => void;
 };
 
 const curveModeOptions: Array<{ value: CurveMode; label: string }> = [
@@ -40,6 +44,8 @@ export function SettingsPage({
   quickHotkeys,
   onQuickHotkeysChange,
   palette,
+  assetLibraries,
+  onAssetLibrariesChange,
 }: SettingsPageProps) {
   return (
     <div className="w-full h-full overflow-auto p-6">
@@ -93,6 +99,8 @@ export function SettingsPage({
           </CardContent>
         </Card>
 
+        <AssetLibrariesCard assetLibraries={assetLibraries} onChange={onAssetLibrariesChange} />
+
         <HotkeySettingsCard hotkeys={quickHotkeys} onChange={onQuickHotkeysChange} palette={palette} />
 
         <Card>
@@ -139,6 +147,51 @@ export function SettingsPage({
         </Card>
       </div>
     </div>
+  );
+}
+
+type AssetLibrariesCardProps = {
+  assetLibraries: AssetLibrariesSettings;
+  onChange: (
+    next: AssetLibrariesSettings | ((prev: AssetLibrariesSettings) => AssetLibrariesSettings)
+  ) => void;
+};
+
+function AssetLibrariesCard({ assetLibraries, onChange }: AssetLibrariesCardProps) {
+  const ambientEnabled = assetLibraries?.ambientcg?.enabled ?? false;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Asset Libraries</CardTitle>
+        <CardDescription>Connect external providers to expand the built-in asset catalog.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <div className="flex flex-col gap-3 rounded-md border border-border/60 bg-muted/10 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">ambientCG</div>
+            <p className="text-xs text-muted-foreground">
+              Browse thousands of free PBR materials, HDRIs, and models hosted by ambientCG directly inside the Assets panel.
+            </p>
+          </div>
+          <label className="flex items-center gap-2 text-xs font-medium">
+            <input
+              type="checkbox"
+              checked={ambientEnabled}
+              onChange={(event) => {
+                const enabled = event.target.checked;
+                onChange((prev) => ({ ...prev, ambientcg: { enabled } }));
+              }}
+              className="h-4 w-4 accent-primary"
+            />
+            <span>{ambientEnabled ? "Enabled" : "Disabled"}</span>
+          </label>
+        </div>
+        <p className="text-[11px] leading-5 text-muted-foreground">
+          When enabled, ambientCG assets appear alongside built-in textures and models. Assets load on demand and respect your
+          search and type filters.
+        </p>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/ui/state/SettingsContext.tsx
+++ b/src/ui/state/SettingsContext.tsx
@@ -5,6 +5,12 @@ export type ThemeName = "dark" | "light";
 
 export type CurveMode = "default" | "smoothstep" | "step" | "straight" | "simplebezier";
 
+export type AssetLibrariesSettings = {
+  ambientcg: {
+    enabled: boolean;
+  };
+};
+
 type SettingsContextValue = {
   theme: ThemeName;
   setTheme: (next: ThemeName) => void;
@@ -12,6 +18,8 @@ type SettingsContextValue = {
   setCurveMode: (next: CurveMode) => void;
   quickHotkeys: QuickNodeHotkey[];
   setQuickHotkeys: (next: QuickNodeHotkey[]) => void;
+  assetLibraries: AssetLibrariesSettings;
+  setAssetLibraries: (next: AssetLibrariesSettings) => void;
 };
 
 const SettingsContext = createContext<SettingsContextValue | null>(null);

--- a/src/viewer.tsx
+++ b/src/viewer.tsx
@@ -138,7 +138,7 @@ function ViewerInner() {
     setCurveMode: () => {},
     quickHotkeys: [],
     setQuickHotkeys: () => {},
-    assetLibraries: { ambientcg: { enabled: false } },
+    assetLibraries: { ambientcg: { enabled: true } },
     setAssetLibraries: () => {},
   }), [theme, curveMode]);
 

--- a/src/viewer.tsx
+++ b/src/viewer.tsx
@@ -138,6 +138,8 @@ function ViewerInner() {
     setCurveMode: () => {},
     quickHotkeys: [],
     setQuickHotkeys: () => {},
+    assetLibraries: { ambientcg: { enabled: false } },
+    setAssetLibraries: () => {},
   }), [theme, curveMode]);
 
   const nodesById = useMemo(() => {

--- a/tests/ambientcg_provider.spec.ts
+++ b/tests/ambientcg_provider.spec.ts
@@ -11,7 +11,7 @@ describe("ambientcg provider", () => {
     vi.restoreAllMocks();
   });
 
-  it("maps API assets into texture and model entries", async () => {
+  it("maps API assets into texture entries", async () => {
     const sampleAsset = {
       assetId: "Wood001",
       displayName: "Wood 001",
@@ -74,7 +74,7 @@ describe("ambientcg provider", () => {
     expect(Array.isArray(result.items)).toBe(true);
     expect(result.items.some((item) => item.label.includes("Color"))).toBe(true);
     expect(result.items.some((item) => item.source.endsWith(".exr"))).toBe(true);
-    expect(result.items.some((item) => item.type === "model")).toBe(true);
+    expect(result.items.every((item) => item.type === "texture")).toBe(true);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -120,8 +120,9 @@ describe("ambientcg provider", () => {
     expect(res.ok).toBe(true);
     const data = await res.json();
     expect(Array.isArray(data.items)).toBe(true);
-    expect(data.items.every((item: any) => item.type === "model")).toBe(true);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(data.items.length).toBe(0);
+    expect(data.cursor).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("streams a file from an ambientcg archive", async () => {

--- a/tests/ambientcg_provider.spec.ts
+++ b/tests/ambientcg_provider.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { zipSync } from "fflate";
+
+describe("ambientcg provider", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("maps API assets into texture and model entries", async () => {
+    const sampleAsset = {
+      assetId: "Wood001",
+      displayName: "Wood 001",
+      dataType: "Material",
+      description: "Wood material",
+      displayCategory: "Wood",
+      tags: ["wood", "pbr"],
+      shortLink: "https://ambientcg.com/a/Wood001",
+      previewLinks: [
+        {
+          name: { slug: "pbr-one-material-maps" },
+          url: "https://example.com#texture_url=https://assets.example.com/color.jpg,https://assets.example.com/normal.jpg&texture_name=Color,Normal",
+        },
+      ],
+      previewImage: {
+        "512-PNG": "https://assets.example.com/preview.png",
+      },
+      downloadFolders: {
+        default: {
+          downloadFiletypeCategories: {
+            exr: {
+              downloads: [
+                {
+                  downloadLink: "https://ambientcg.com/get?file=Wood001_4K-HDR.exr",
+                  filetype: "exr",
+                  attribute: "4K-HDR",
+                  zipContent: [],
+                },
+              ],
+            },
+            zip: {
+              downloads: [
+                {
+                  downloadLink: "https://ambientcg.com/get?file=Wood001_1K-JPG.zip",
+                  attribute: "1K-JPG",
+                  zipContent: ["Wood001_1K-JPG.usdc", "Wood001_1K-JPG_Color.jpg"],
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const fetchMock = vi.spyOn(globalThis, "fetch" as any).mockResolvedValue(
+      new Response(
+        JSON.stringify({ foundAssets: [sampleAsset], nextPageHttp: null, numberOfResults: 1 }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+
+    const { loadAmbientcgLibrary } = await import("../src/server/providers/ambientcg");
+    const library = await loadAmbientcgLibrary();
+    expect(Array.isArray(library.textures)).toBe(true);
+    expect(library.textures.some((item) => item.label.includes("Color"))).toBe(true);
+    expect(library.textures.some((item) => item.source.endsWith(".exr"))).toBe(true);
+    expect(Array.isArray(library.models)).toBe(true);
+    expect(library.models[0]?.source).toContain("/api/assets/ambientcg/file");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("streams a file from an ambientcg archive", async () => {
+    const fileData = new Uint8Array([1, 2, 3, 4]);
+    const zipped = zipSync({ "Sample.usdc": fileData });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch" as any)
+      .mockResolvedValue(
+        new Response(zipped.slice().buffer, { status: 200, headers: { "content-type": "application/zip" } })
+      );
+
+    const { ambientcgFileHandler } = await import("../src/server/providers/ambientcg");
+    const req = new Request(
+      "http://localhost/api/assets/ambientcg/file?download=https://ambientcg.com/get?file=Wood001_1K-JPG.zip&file=Sample.usdc"
+    );
+    const res = await ambientcgFileHandler(req);
+    expect(res.ok).toBe(true);
+    expect(res.headers.get("content-type")).toBe("application/octet-stream");
+    const buffer = new Uint8Array(await res.arrayBuffer());
+    expect(buffer).toEqual(fileData);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/ambientcg_provider.spec.ts
+++ b/tests/ambientcg_provider.spec.ts
@@ -56,20 +56,71 @@ describe("ambientcg provider", () => {
       },
     };
 
-    const fetchMock = vi.spyOn(globalThis, "fetch" as any).mockResolvedValue(
-      new Response(
-        JSON.stringify({ foundAssets: [sampleAsset], nextPageHttp: null, numberOfResults: 1 }),
-        { status: 200, headers: { "content-type": "application/json" } }
-      )
-    );
+    const fetchMock = vi.spyOn(globalThis, "fetch" as any).mockImplementation((...args: unknown[]) => {
+      const [url] = args as [string];
+      if (url.startsWith("https://ambientcg.com/api/v2/full_json")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ foundAssets: [sampleAsset], nextPageHttp: null }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          )
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
 
-    const { loadAmbientcgLibrary } = await import("../src/server/providers/ambientcg");
-    const library = await loadAmbientcgLibrary();
-    expect(Array.isArray(library.textures)).toBe(true);
-    expect(library.textures.some((item) => item.label.includes("Color"))).toBe(true);
-    expect(library.textures.some((item) => item.source.endsWith(".exr"))).toBe(true);
-    expect(Array.isArray(library.models)).toBe(true);
-    expect(library.models[0]?.source).toContain("/api/assets/ambientcg/file");
+    const { queryAmbientcgItems } = await import("../src/server/providers/ambientcg");
+    const result = await queryAmbientcgItems();
+    expect(Array.isArray(result.items)).toBe(true);
+    expect(result.items.some((item) => item.label.includes("Color"))).toBe(true);
+    expect(result.items.some((item) => item.source.endsWith(".exr"))).toBe(true);
+    expect(result.items.some((item) => item.type === "model")).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles catalog handler queries", async () => {
+    const sampleAsset = {
+      assetId: "Model001",
+      displayName: "Model 001",
+      dataType: "3DScan",
+      downloadFolders: {
+        default: {
+          downloadFiletypeCategories: {
+            zip: {
+              downloads: [
+                {
+                  downloadLink: "https://ambientcg.com/get?file=Model001_1K.zip",
+                  attribute: "1K",
+                  zipContent: ["Model001_1K.glb"],
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const fetchMock = vi.spyOn(globalThis, "fetch" as any).mockImplementation((...args: unknown[]) => {
+      const [url] = args as [string];
+      if (url.startsWith("https://ambientcg.com/api/v2/full_json")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ foundAssets: [sampleAsset], nextPageHttp: null }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          )
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const { ambientcgCatalogHandler } = await import("../src/server/providers/ambientcg");
+    const res = await ambientcgCatalogHandler(
+      new Request("http://localhost/api/assets/ambientcg/catalog?type=model")
+    );
+    expect(res.ok).toBe(true);
+    const data = await res.json();
+    expect(Array.isArray(data.items)).toBe(true);
+    expect(data.items.every((item: any) => item.type === "model")).toBe(true);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/api_assets_route.spec.ts
+++ b/tests/api_assets_route.spec.ts
@@ -1,9 +1,45 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { assetsHandler } from "../src/server/assets";
+import { loadAmbientcgCategories } from "../src/server/providers/ambientcg";
+
+vi.mock("../src/server/providers/ambientcg", () => {
+  const loadAmbientcgCategoriesMock = vi.fn(async () => [
+    {
+      id: "ambientcg:textures",
+      label: "ambientCG • Textures",
+      items: [
+        {
+          id: "ambientcg:sample",
+          label: "Sample Asset",
+          type: "texture",
+          source: "https://example.com/sample.png",
+          builtin: true,
+          preview: "https://example.com/sample.png",
+          provider: {
+            id: "ambientcg",
+            name: "ambientCG",
+            assetId: "Sample001",
+            assetUrl: "https://ambientcg.com/a/Sample001",
+          },
+        },
+      ],
+    },
+  ]);
+  return {
+    AMBIENT_CG_PROVIDER_ID: "ambientcg",
+    loadAmbientcgCategories: loadAmbientcgCategoriesMock,
+  };
+});
+
+const ambientCategoriesMock = vi.mocked(loadAmbientcgCategories);
+
+beforeEach(() => {
+  ambientCategoriesMock.mockClear();
+});
 
 describe("/api/assets route", () => {
   it("returns categories with asset metadata", async () => {
-    const res = await assetsHandler();
+    const res = await assetsHandler(new Request("http://localhost/api/assets"));
     expect(res.ok).toBe(true);
     const data = await res.json();
     expect(typeof data.version).toBe("number");
@@ -22,5 +58,17 @@ describe("/api/assets route", () => {
         expect(item.builtin).toBe(true);
       }
     }
+    expect(ambientCategoriesMock).not.toHaveBeenCalled();
+  });
+
+  it("merges ambientcg provider categories when requested", async () => {
+    const res = await assetsHandler(new Request("http://localhost/api/assets?provider=ambientcg"));
+    expect(res.ok).toBe(true);
+    const data = await res.json();
+    const ambientCategory = (data.categories as any[]).find((cat) => cat.id === "ambientcg:textures");
+    expect(ambientCategory).toBeTruthy();
+    expect(Array.isArray(ambientCategory.items)).toBe(true);
+    expect(ambientCategory.items[0]?.provider?.id).toBe("ambientcg");
+    expect(ambientCategoriesMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/api_assets_route.spec.ts
+++ b/tests/api_assets_route.spec.ts
@@ -1,41 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { assetsHandler } from "../src/server/assets";
-import { loadAmbientcgCategories } from "../src/server/providers/ambientcg";
-
-vi.mock("../src/server/providers/ambientcg", () => {
-  const loadAmbientcgCategoriesMock = vi.fn(async () => [
-    {
-      id: "ambientcg:textures",
-      label: "ambientCG • Textures",
-      items: [
-        {
-          id: "ambientcg:sample",
-          label: "Sample Asset",
-          type: "texture",
-          source: "https://example.com/sample.png",
-          builtin: true,
-          preview: "https://example.com/sample.png",
-          provider: {
-            id: "ambientcg",
-            name: "ambientCG",
-            assetId: "Sample001",
-            assetUrl: "https://ambientcg.com/a/Sample001",
-          },
-        },
-      ],
-    },
-  ]);
-  return {
-    AMBIENT_CG_PROVIDER_ID: "ambientcg",
-    loadAmbientcgCategories: loadAmbientcgCategoriesMock,
-  };
-});
-
-const ambientCategoriesMock = vi.mocked(loadAmbientcgCategories);
-
-beforeEach(() => {
-  ambientCategoriesMock.mockClear();
-});
 
 describe("/api/assets route", () => {
   it("returns categories with asset metadata", async () => {
@@ -58,17 +22,12 @@ describe("/api/assets route", () => {
         expect(item.builtin).toBe(true);
       }
     }
-    expect(ambientCategoriesMock).not.toHaveBeenCalled();
   });
 
-  it("merges ambientcg provider categories when requested", async () => {
+  it("ignores provider query parameters", async () => {
     const res = await assetsHandler(new Request("http://localhost/api/assets?provider=ambientcg"));
     expect(res.ok).toBe(true);
     const data = await res.json();
-    const ambientCategory = (data.categories as any[]).find((cat) => cat.id === "ambientcg:textures");
-    expect(ambientCategory).toBeTruthy();
-    expect(Array.isArray(ambientCategory.items)).toBe(true);
-    expect(ambientCategory.items[0]?.provider?.id).toBe("ambientcg");
-    expect(ambientCategoriesMock).toHaveBeenCalledTimes(1);
+    expect(Array.isArray(data.categories)).toBe(true);
   });
 });

--- a/tests/settings_asset_libraries.spec.tsx
+++ b/tests/settings_asset_libraries.spec.tsx
@@ -1,0 +1,106 @@
+/* @vitest-environment jsdom */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const { loadUserAssetsMock, saveUserAssetsMock } = vi.hoisted(() => ({
+  loadUserAssetsMock: vi.fn(async () => [] as any[]),
+  saveUserAssetsMock: vi.fn(async (_assets: any[]) => {}),
+}));
+
+vi.mock("@xyflow/react", () => ({
+  ReactFlowProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ReactFlow: () => null,
+  Background: () => null,
+  Controls: () => null,
+  MiniMap: () => null,
+  Position: { Left: "left", Right: "right" },
+}));
+
+vi.mock("@/core/assets/userAssets", () => ({
+  appendUserAsset: (list: any[], asset: any) => [...list, { ...asset, builtin: false }],
+  createUserAssetId: () => "user-created",
+  loadUserAssets: loadUserAssetsMock,
+  removeUserAssetById: (list: any[], id: string) => list.filter((asset) => asset.id !== id),
+  saveUserAssets: saveUserAssetsMock,
+  USER_ASSETS_CHANGED_EVENT: "osg:user-assets:changed",
+}));
+
+import { SettingsPage } from "../src/ui/settings/SettingsPage";
+
+describe("SettingsPage asset libraries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadUserAssetsMock.mockResolvedValue([]);
+    saveUserAssetsMock.mockResolvedValue();
+  });
+
+  function renderSettingsPage() {
+    render(
+      <SettingsPage
+        curveMode="default"
+        onCurveModeChange={vi.fn()}
+        theme="dark"
+        onThemeChange={vi.fn()}
+        quickHotkeys={[]}
+        onQuickHotkeysChange={vi.fn()}
+        palette={null}
+        assetLibraries={{ ambientcg: { enabled: true } }}
+        onAssetLibrariesChange={vi.fn()}
+      />
+    );
+  }
+
+  it("allows users to add manual asset URLs", async () => {
+    renderSettingsPage();
+
+    await waitFor(() => expect(loadUserAssetsMock).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: /add manual asset/i }));
+
+    fireEvent.change(screen.getByLabelText(/asset url/i), {
+      target: { value: "https://example.com/diffuse.png" },
+    });
+    fireEvent.change(screen.getByLabelText(/display name/i), {
+      target: { value: "Diffuse" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save asset/i }));
+
+    await waitFor(() => expect(saveUserAssetsMock).toHaveBeenCalledTimes(1));
+    const payload = saveUserAssetsMock.mock.calls[0][0];
+    expect(Array.isArray(payload)).toBe(true);
+    expect(payload[0]).toMatchObject({
+      label: "Diffuse",
+      type: "texture",
+      source: "https://example.com/diffuse.png",
+      builtin: false,
+    });
+    expect(screen.getByText("Diffuse")).toBeTruthy();
+  });
+
+  it("lets users remove saved manual assets", async () => {
+    loadUserAssetsMock.mockResolvedValueOnce([
+      {
+        id: "user-existing",
+        label: "Wood",
+        type: "texture",
+        source: "https://assets.example.com/wood.png",
+        builtin: false,
+      },
+    ]);
+
+    renderSettingsPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Wood")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /remove wood/i }));
+
+    await waitFor(() => expect(saveUserAssetsMock).toHaveBeenCalledWith([]));
+    await waitFor(() => {
+      expect(screen.queryByText("Wood")).toBeNull();
+    });
+  });
+});

--- a/tests/ui_pointer_capture.spec.tsx
+++ b/tests/ui_pointer_capture.spec.tsx
@@ -76,6 +76,24 @@ vi.mock("../src/components/PreviewPanel", () => ({ PreviewPanel: () => null }));
 import GraphNode from "../src/components/GraphNode";
 import CodeBlock from "../src/components/CodeBlock";
 import { AssetsPanel } from "../src/components/AssetsPanel";
+import { SettingsProvider } from "../src/ui/state/SettingsContext";
+
+function createSettingsValue() {
+  return {
+    theme: "dark",
+    setTheme: vi.fn(),
+    curveMode: "default",
+    setCurveMode: vi.fn(),
+    quickHotkeys: [],
+    setQuickHotkeys: vi.fn(),
+    assetLibraries: {
+      ambientcg: {
+        enabled: false,
+      },
+    },
+    setAssetLibraries: vi.fn(),
+  };
+}
 
 function renderIntoContainer(element: React.ReactElement) {
   const container = document.createElement("div");
@@ -213,9 +231,11 @@ describe("In-node widgets keep focus", () => {
     const pointerSpy = vi.fn();
     const wheelSpy = vi.fn();
     const { container, cleanup } = renderIntoContainer(
-      <div onPointerDown={pointerSpy} onWheel={wheelSpy}>
-        <AssetsPanel variant="node" />
-      </div>
+      <SettingsProvider value={createSettingsValue()}>
+        <div onPointerDown={pointerSpy} onWheel={wheelSpy}>
+          <AssetsPanel variant="node" />
+        </div>
+      </SettingsProvider>
     );
 
     await flushPromises(3);

--- a/tests/ui_pointer_capture.spec.tsx
+++ b/tests/ui_pointer_capture.spec.tsx
@@ -61,9 +61,17 @@ vi.mock("@/core/assets/kind", () => ({
   TEXTURE_EXTENSIONS: ["png"],
   ASSET_DRAG_MIME: "application/x-asset",
 }), { virtual: true });
-vi.mock("@/lib/storage", () => ({
-  persistGet: vi.fn(() => Promise.resolve(null)),
-  persistSet: vi.fn(() => Promise.resolve()),
+const { loadUserAssetsMock, saveUserAssetsMock } = vi.hoisted(() => ({
+  loadUserAssetsMock: vi.fn(() => Promise.resolve([])),
+  saveUserAssetsMock: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("@/core/assets/userAssets", () => ({
+  appendUserAsset: (list: any[], asset: any) => [...list, asset],
+  createUserAssetId: () => "user-mock",
+  loadUserAssets: loadUserAssetsMock,
+  removeUserAssetById: (list: any[], id: string) => list.filter((asset) => asset.id !== id),
+  saveUserAssets: saveUserAssetsMock,
+  USER_ASSETS_CHANGED_EVENT: "osg:user-assets:changed",
 }), { virtual: true });
 vi.mock("@/core/assets/search", () => ({
   buildAssetHaystack: (asset: any) => `${asset.label}|${asset.type}`.toLowerCase(),

--- a/tests/user_assets_storage.spec.ts
+++ b/tests/user_assets_storage.spec.ts
@@ -1,0 +1,74 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { persistGetMock, persistSetMock } = vi.hoisted(() => ({
+  persistGetMock: vi.fn(),
+  persistSetMock: vi.fn(),
+}));
+
+vi.mock("@/lib/storage", () => ({
+  persistGet: persistGetMock,
+  persistSet: persistSetMock,
+}));
+
+import {
+  appendUserAsset,
+  loadUserAssets,
+  removeUserAssetById,
+  saveUserAssets,
+  USER_ASSETS_CHANGED_EVENT,
+  USER_ASSETS_STORAGE_KEY,
+} from "../src/core/assets/userAssets";
+
+describe("user asset storage", () => {
+  beforeEach(() => {
+    persistGetMock.mockReset();
+    persistSetMock.mockReset();
+  });
+
+  it("loads and sanitizes stored assets", async () => {
+    persistGetMock.mockResolvedValue([
+      { id: "a", label: " Albedo ", type: "texture", source: "https://example.com/a.png" },
+      { id: "b", label: "", type: "model", source: "https://example.com/model.glb", tags: [] },
+      null,
+    ]);
+
+    const assets = await loadUserAssets();
+    expect(assets).toHaveLength(2);
+    expect(assets[0]).toMatchObject({ label: "Albedo", builtin: false, type: "texture" });
+    expect(assets[1]).toMatchObject({ label: "https://example.com/model.glb", type: "model", tags: ["user", "model"] });
+  });
+
+  it("persists normalized assets and dispatches change events", async () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+    persistSetMock.mockResolvedValue(undefined);
+
+    await saveUserAssets([
+      { id: "a", label: "Asset", type: "texture", source: "https://example.com/a.png", builtin: true } as any,
+    ]);
+
+    expect(persistSetMock).toHaveBeenCalledWith(
+      USER_ASSETS_STORAGE_KEY,
+      expect.arrayContaining([expect.objectContaining({ builtin: false, type: "texture" })])
+    );
+    expect(dispatchSpy).toHaveBeenCalled();
+    const event = dispatchSpy.mock.calls[0][0] as CustomEvent;
+    expect(event.type).toBe(USER_ASSETS_CHANGED_EVENT);
+    dispatchSpy.mockRestore();
+  });
+
+  it("appends and removes entries immutably", () => {
+    const base: any[] = [];
+    const appended = appendUserAsset(base, {
+      id: "x",
+      label: "Custom",
+      type: "texture",
+      source: "https://example.com/custom.png",
+    } as any);
+    expect(appended).toHaveLength(1);
+    expect(appended[0].builtin).toBe(false);
+    const removed = removeUserAssetById(appended, "x");
+    expect(removed).toHaveLength(0);
+    expect(base).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- integrate the ambientCG catalog into the asset pipeline with provider metadata, caching, and ZIP streaming support
- add settings persistence and UI to toggle external asset libraries and surface provider context inside the assets panel
- expand asset schemas/tests for provider data while covering the new server endpoints and UI behaviour

## Testing
- bun install --frozen-lockfile
- bun run lint
- bun x tsc -p tsconfig.json --noEmit
- bun run test
- bun run test:coverage
- bun run build
- bun run test:e2e:install
- bun run test:e2e
- bun run validate:shaders


------
https://chatgpt.com/codex/tasks/task_e_68e67f3fabc08332908e1d197aa2bd00