### PR TITLE
feat: add lighting profiles to 3d preview

### DIFF
--- a/bun-env.d.ts
+++ b/bun-env.d.ts
@@ -24,6 +24,11 @@ declare module "*.png" {
   export default path;
 }
 
+declare module "*.json" {
+  const value: unknown;
+  export default value;
+}
+
 // Fallback types for Three.js examples modules used at runtime
 declare module "three/examples/jsm/environments/RoomEnvironment.js" {
   import type { Scene } from "three";

--- a/data/nodes/editor/preview.json
+++ b/data/nodes/editor/preview.json
@@ -29,6 +29,12 @@
       "type": "string",
       "label": "Model Label",
       "default": ""
+    },
+    {
+      "id": "lighting_profile",
+      "type": "string",
+      "label": "Lighting Profile",
+      "default": "three-point-studio"
     }
   ]
 }

--- a/data/preview/lighting_profiles.json
+++ b/data/preview/lighting_profiles.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "three-point-studio",
+    "label": "3-Point Studio",
+    "description": "Neutral studio rig with balanced key, fill, and rim lights.",
+    "exposure": 1.3,
+    "ambient": [0.08, 0.08, 0.08],
+    "lights": [
+      {
+        "type": "directional",
+        "direction": [-0.35, 0.8, 0.6],
+        "color": [1.0, 1.0, 1.0],
+        "intensity": 3.0
+      },
+      {
+        "type": "directional",
+        "direction": [0.6, 0.2, 0.2],
+        "color": [0.85, 0.95, 1.05],
+        "intensity": 1.2
+      },
+      {
+        "type": "directional",
+        "direction": [-0.2, 0.3, -0.9],
+        "color": [0.95, 0.9, 1.1],
+        "intensity": 2.0
+      }
+    ]
+  },
+  {
+    "id": "natural-sun",
+    "label": "Natural Sun",
+    "description": "Warm morning sunlight with a subtle sky fill and soft bounce.",
+    "exposure": 1.35,
+    "ambient": [0.06, 0.07, 0.09],
+    "lights": [
+      {
+        "type": "directional",
+        "direction": [-0.4, 0.85, 0.5],
+        "color": [1.05, 0.98, 0.9],
+        "intensity": 3.5
+      },
+      {
+        "type": "directional",
+        "direction": [0.5, 0.3, 0.2],
+        "color": [0.75, 0.85, 1.05],
+        "intensity": 1.4
+      },
+      {
+        "type": "directional",
+        "direction": [-0.15, 0.25, -0.95],
+        "color": [1.0, 0.9, 1.1],
+        "intensity": 1.8
+      }
+    ]
+  },
+  {
+    "id": "hdr-overcast",
+    "label": "HDR Overcast",
+    "description": "Soft overcast daylight with gentle wrap-around illumination.",
+    "exposure": 1.1,
+    "ambient": [0.12, 0.13, 0.15],
+    "lights": [
+      {
+        "type": "directional",
+        "direction": [-0.25, 0.9, 0.35],
+        "color": [0.95, 0.97, 1.05],
+        "intensity": 2.1
+      },
+      {
+        "type": "directional",
+        "direction": [0.3, 0.4, 0.1],
+        "color": [0.8, 0.88, 1.0],
+        "intensity": 1.1
+      },
+      {
+        "type": "directional",
+        "direction": [-0.1, 0.15, -0.98],
+        "color": [0.9, 0.92, 1.0],
+        "intensity": 1.5
+      }
+    ]
+  },
+  {
+    "id": "product-softbox",
+    "label": "Product Softbox",
+    "description": "High-key setup inspired by light tent product photography.",
+    "exposure": 1.5,
+    "ambient": [0.18, 0.18, 0.2],
+    "lights": [
+      {
+        "type": "directional",
+        "direction": [-0.2, 0.75, 0.6],
+        "color": [1.05, 1.05, 1.1],
+        "intensity": 3.2
+      },
+      {
+        "type": "directional",
+        "direction": [0.4, 0.3, 0.35],
+        "color": [1.0, 1.05, 1.1],
+        "intensity": 2.4
+      },
+      {
+        "type": "directional",
+        "direction": [-0.15, 0.1, -0.98],
+        "color": [1.05, 1.0, 1.1],
+        "intensity": 2.1
+      }
+    ]
+  }
+]

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -22,6 +22,8 @@ import {
   collectSamplerSettings,
   cloneTextureForUniform,
 } from "@/core/preview/graphAssets";
+import type { LightingProfile, LightingProfileLight } from "@/core/preview/lightingProfiles";
+import { DEFAULT_LIGHTING_PROFILE_ID, getLightingProfile, lightingProfiles } from "@/core/preview/lightingProfiles";
 
 type PreviewAsset = {
   id?: string;
@@ -42,6 +44,50 @@ type PreviewPanelProps = {
 };
 
 type Primitive = "sphere" | "cube" | "cylinder" | "custom";
+
+type Vec3Tuple = [number, number, number];
+
+const FALLBACK_LIGHT_DIRECTIONS: Vec3Tuple[] = [
+  [-0.35, 0.8, 0.6],
+  [0.6, 0.2, 0.2],
+  [-0.2, 0.3, -0.9],
+];
+
+const FALLBACK_LIGHT_COLORS: Vec3Tuple[] = [
+  [3.0, 3.0, 3.0],
+  [1.2, 1.2, 1.2],
+  [2.0, 2.0, 2.0],
+];
+
+const FALLBACK_AMBIENT: Vec3Tuple = [0.08, 0.08, 0.08];
+const FALLBACK_EXPOSURE = 1.3;
+
+function normalizeTuple(vec: Vec3Tuple): Vec3Tuple {
+  const [x, y, z] = vec;
+  const len = Math.hypot(x, y, z);
+  if (!Number.isFinite(len) || len === 0) return [0, 0, 1];
+  return [x / len, y / len, z / len];
+}
+
+function resolveDirection(light: LightingProfileLight | undefined, fallback: Vec3Tuple): Vec3Tuple {
+  let dir: Vec3Tuple | undefined;
+  if (light) {
+    if (light.direction) {
+      dir = light.direction;
+    } else if (light.position) {
+      dir = [-light.position[0], -light.position[1], -light.position[2]];
+    }
+  }
+  if (!dir) dir = fallback;
+  return normalizeTuple(dir);
+}
+
+function resolveColor(light: LightingProfileLight | undefined, fallback: Vec3Tuple): Vec3Tuple {
+  if (!light) return fallback;
+  const [r, g, b] = light.color;
+  const intensity = Number.isFinite(light.intensity) ? light.intensity : 1;
+  return [r * intensity, g * intensity, b * intensity];
+}
 
 function disposeMaterial(
   mat: any | null | undefined,
@@ -102,6 +148,17 @@ export function PreviewPanel({ graph, className, variant = "overlay", getPropert
   const [modelStatus, setModelStatus] = useState<string | null>(null);
   const [modelDropActive, setModelDropActive] = useState(false);
   const [customModel, setCustomModel] = useState<{ source: string; label: string } | null>(null);
+  const [lightingProfileId, setLightingProfileId] = useState<string>(() => {
+    const prop = getProperty?.("lighting_profile");
+    if (typeof prop === "string" && lightingProfiles.some((profile) => profile.id === prop)) return prop;
+    const stored = typeof localStorage !== "undefined" ? localStorage.getItem("previewPanel.lightingProfile") : null;
+    if (stored && lightingProfiles.some((profile) => profile.id === stored)) return stored;
+    return DEFAULT_LIGHTING_PROFILE_ID;
+  });
+
+  const lightingProfile = useMemo(() => getLightingProfile(lightingProfileId), [lightingProfileId]);
+  const lightingDescription = lightingProfile.description.trim();
+  const hasLightingDescription = lightingDescription.length > 0;
 
   useEffect(() => { if (typeof localStorage !== "undefined") localStorage.setItem("previewPanel.width", String(width)); }, [width]);
   // Keep latest setProperty in a ref to avoid effect dependency loops
@@ -109,6 +166,14 @@ export function PreviewPanel({ graph, className, variant = "overlay", getPropert
   useEffect(() => { setPropertyRef.current = setProperty; }, [setProperty]);
   const setAssetRef = useRef<typeof setAsset>(setAsset);
   useEffect(() => { setAssetRef.current = setAsset; }, [setAsset]);
+  const lightingProfileRef = useRef<LightingProfile | null>(lightingProfile);
+  useEffect(() => { lightingProfileRef.current = lightingProfile; }, [lightingProfile]);
+
+  useEffect(() => {
+    const id = lightingProfile.id;
+    if (setPropertyRef.current) setPropertyRef.current("lighting_profile", id);
+    if (typeof localStorage !== "undefined") localStorage.setItem("previewPanel.lightingProfile", id);
+  }, [lightingProfile]);
 
   useEffect(() => {
     // Persist primitive to node property when available; otherwise use localStorage fallback
@@ -379,16 +444,23 @@ export function PreviewPanel({ graph, className, variant = "overlay", getPropert
         cam.updateMatrixWorld();
         cam.updateProjectionMatrix();
         const view = cam.matrixWorldInverse;
-        const key = new (THREE as any).Vector3(-0.35, 0.8, 0.6).normalize();
-        const fill = new (THREE as any).Vector3(0.6, 0.2, 0.2).normalize();
-        const rim = new (THREE as any).Vector3(-0.2, 0.3, -0.9).normalize();
-        key.transformDirection(view);
-        fill.transformDirection(view);
-        rim.transformDirection(view);
-        const u = (materialRef.current.uniforms as any);
-        if (u.uKeyDir?.value?.set) u.uKeyDir.value.set(key.x, key.y, key.z);
-        if (u.uFillDir?.value?.set) u.uFillDir.value.set(fill.x, fill.y, fill.z);
-        if (u.uRimDir?.value?.set) u.uRimDir.value.set(rim.x, rim.y, rim.z);
+        const viewMatrix = new (THREE as any).Matrix3().setFromMatrix4(view);
+        const profile = lightingProfileRef.current;
+        const lights = profile?.lights ?? [];
+        const dirTuples = FALLBACK_LIGHT_DIRECTIONS.map((fallback, index) => resolveDirection(lights[index], fallback));
+        const vectors = dirTuples.map((tuple) =>
+          new (THREE as any).Vector3(tuple[0], tuple[1], tuple[2]).applyMatrix3(viewMatrix).normalize()
+        );
+        const u = materialRef.current.uniforms as any;
+        const entries: Array<[string, any]> = [
+          ["uKeyDir", vectors[0]],
+          ["uFillDir", vectors[1]],
+          ["uRimDir", vectors[2]],
+        ];
+        for (const [name, vec] of entries) {
+          const uniform = u?.[name];
+          if (uniform?.value?.set && vec) uniform.value.set(vec.x, vec.y, vec.z);
+        }
       }
       try {
         renderer.render(scene, camera);
@@ -490,7 +562,11 @@ export function PreviewPanel({ graph, className, variant = "overlay", getPropert
         const src = typeof getProperty === "function" ? (getProperty("model_source") as string | undefined) : undefined;
         const label = typeof getProperty === "function" ? (getProperty("model_label") as string | undefined) : undefined;
         const prim = typeof getProperty === "function" ? (getProperty("primitive") as Primitive | undefined) : undefined;
+        const profileProp = typeof getProperty === "function" ? (getProperty("lighting_profile") as string | undefined) : undefined;
         if (typeof prim === "string") setPrimitive(prim as Primitive);
+        if (typeof profileProp === "string" && lightingProfiles.some((profile) => profile.id === profileProp)) {
+          setLightingProfileId(profileProp);
+        }
         if (src) {
           void loadModelAsset(src, label || "Model", { persist: false, asset: ((asset as any) ?? null) });
         }
@@ -604,6 +680,12 @@ export function PreviewPanel({ graph, className, variant = "overlay", getPropert
         }
       }
     }
+    const lights = lightingProfile.lights;
+    const worldDirectionTuples = FALLBACK_LIGHT_DIRECTIONS.map((fallback, index) => resolveDirection(lights[index], fallback));
+    const colorTuples = FALLBACK_LIGHT_COLORS.map((fallback, index) => resolveColor(lights[index], fallback));
+    const ambientTuple = lightingProfile.ambient ?? FALLBACK_AMBIENT;
+    const exposure = Number.isFinite(lightingProfile.exposure) ? lightingProfile.exposure : FALLBACK_EXPOSURE;
+
     // Ensure preview-owned environment/lighting uniforms exist with sensible defaults
     // Directions are provided in view space (updated every frame), initialize now to avoid a black first frame
     try {
@@ -611,20 +693,35 @@ export function PreviewPanel({ graph, className, variant = "overlay", getPropert
       cam.updateMatrixWorld();
       cam.updateProjectionMatrix();
       const view = cam.matrixWorldInverse;
-      const keyDir = new (THREE as any).Vector3(-0.35, 0.8, 0.6).normalize().applyMatrix3(new (THREE as any).Matrix3().setFromMatrix4(view));
-      const fillDir = new (THREE as any).Vector3(0.6, 0.2, 0.2).normalize().applyMatrix3(new (THREE as any).Matrix3().setFromMatrix4(view));
-      const rimDir = new (THREE as any).Vector3(-0.2, 0.3, -0.9).normalize().applyMatrix3(new (THREE as any).Matrix3().setFromMatrix4(view));
-      if (!uniforms.uKeyDir) uniforms.uKeyDir = { value: new (THREE as any).Vector3(keyDir.x, keyDir.y, keyDir.z) };
-      if (!uniforms.uFillDir) uniforms.uFillDir = { value: new (THREE as any).Vector3(fillDir.x, fillDir.y, fillDir.z) };
-      if (!uniforms.uRimDir) uniforms.uRimDir = { value: new (THREE as any).Vector3(rimDir.x, rimDir.y, rimDir.z) };
+      const viewMatrix = new (THREE as any).Matrix3().setFromMatrix4(view);
+      const dirVectors = worldDirectionTuples.map((tuple) =>
+        new (THREE as any).Vector3(tuple[0], tuple[1], tuple[2]).applyMatrix3(viewMatrix).normalize()
+      );
+      const [keyDir, fillDir, rimDir] = dirVectors;
+      if (!uniforms.uKeyDir) uniforms.uKeyDir = { value: keyDir };
+      else if (uniforms.uKeyDir.value?.set) uniforms.uKeyDir.value.set(keyDir.x, keyDir.y, keyDir.z);
+      else uniforms.uKeyDir.value = keyDir;
+      if (!uniforms.uFillDir) uniforms.uFillDir = { value: fillDir };
+      else if (uniforms.uFillDir.value?.set) uniforms.uFillDir.value.set(fillDir.x, fillDir.y, fillDir.z);
+      else uniforms.uFillDir.value = fillDir;
+      if (!uniforms.uRimDir) uniforms.uRimDir = { value: rimDir };
+      else if (uniforms.uRimDir.value?.set) uniforms.uRimDir.value.set(rimDir.x, rimDir.y, rimDir.z);
+      else uniforms.uRimDir.value = rimDir;
     } catch {
-      // no-op
+      const fallbackVectors = worldDirectionTuples.map((tuple) => new (THREE as any).Vector3(tuple[0], tuple[1], tuple[2]));
+      const [keyDir, fillDir, rimDir] = fallbackVectors;
+      if (!uniforms.uKeyDir) uniforms.uKeyDir = { value: keyDir };
+      if (!uniforms.uFillDir) uniforms.uFillDir = { value: fillDir };
+      if (!uniforms.uRimDir) uniforms.uRimDir = { value: rimDir };
     }
-    if (!uniforms.uKeyColor) uniforms.uKeyColor = { value: new (THREE as any).Vector3(3.0, 3.0, 3.0) } as any;
-    if (!uniforms.uFillColor) uniforms.uFillColor = { value: new (THREE as any).Vector3(1.2, 1.2, 1.2) } as any;
-    if (!uniforms.uRimColor) uniforms.uRimColor = { value: new (THREE as any).Vector3(2.0, 2.0, 2.0) } as any;
-    if (!uniforms.uAmbient) uniforms.uAmbient = { value: new (THREE as any).Vector3(0.08, 0.08, 0.08) } as any;
-    if (!uniforms.uExposure) uniforms.uExposure = { value: 1.3 } as any;
+
+    const colorVectors = colorTuples.map((tuple) => new (THREE as any).Vector3(tuple[0], tuple[1], tuple[2]));
+    const [keyColor, fillColor, rimColor] = colorVectors;
+    uniforms.uKeyColor = { value: keyColor } as any;
+    uniforms.uFillColor = { value: fillColor } as any;
+    uniforms.uRimColor = { value: rimColor } as any;
+    uniforms.uAmbient = { value: new (THREE as any).Vector3(ambientTuple[0], ambientTuple[1], ambientTuple[2]) } as any;
+    uniforms.uExposure = { value: exposure } as any;
     if (!uniforms.uTime) uniforms.uTime = { value: 0 } as any;
     const mat = new (THREE as any).ShaderMaterial({
       vertexShader: defaultVertexShader(vertexChunk, parsed),
@@ -693,7 +790,7 @@ export function PreviewPanel({ graph, className, variant = "overlay", getPropert
     return () => {
       cancelled = true;
     };
-  }, [ensureSamplerFallback, fragCode, vertexChunk, wireframe, textureAssignments, samplerSettings]);
+  }, [ensureSamplerFallback, fragCode, vertexChunk, wireframe, textureAssignments, samplerSettings, lightingProfile]);
 
   const handleCanvasDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
     if (!event.dataTransfer?.types.includes(ASSET_DRAG_MIME)) return;
@@ -779,6 +876,20 @@ export function PreviewPanel({ graph, className, variant = "overlay", getPropert
               </SelectContent>
             </Select>
           </div>
+          <div className="min-w-[160px]">
+            <Select value={lightingProfile.id} onValueChange={(value) => { setLightingProfileId(value); setProperty?.("lighting_profile", value); }}>
+              <SelectTrigger aria-label="Lighting profile" title={hasLightingDescription ? lightingDescription : undefined}>
+                <SelectValue placeholder="Lighting" />
+              </SelectTrigger>
+              <SelectContent>
+                {lightingProfiles.map((profile) => (
+                  <SelectItem key={profile.id} value={profile.id}>
+                    {profile.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
           <label className="text-xs inline-flex items-center gap-1 select-none cursor-pointer"><input type="checkbox" checked={autoRotate} onChange={(e) => setAutoRotate(e.target.checked)} /> rotate</label>
           <label className="text-xs inline-flex items-center gap-1 select-none cursor-pointer"><input type="checkbox" checked={wireframe} onChange={(e) => setWireframe(e.target.checked)} /> wireframe</label>
           <label className="text-xs inline-flex items-center gap-1 select-none cursor-pointer"><input type="checkbox" checked={useEnv} onChange={(e) => setUseEnv(e.target.checked)} /> env</label>
@@ -823,7 +934,7 @@ export function PreviewPanel({ graph, className, variant = "overlay", getPropert
         <CardHeader className="py-3 px-4 flex flex-row items-center justify-end">
           <div className="flex items-center gap-2">
             <div className="min-w-[120px]">
-            <Select value={primitive} onValueChange={(v) => { const next = v as Primitive; setPrimitive(next); setProperty?.("primitive", next); }}>
+              <Select value={primitive} onValueChange={(v) => { const next = v as Primitive; setPrimitive(next); setProperty?.("primitive", next); }}>
                 <SelectTrigger aria-label="Primitive">
                   <SelectValue placeholder="Primitive" />
                 </SelectTrigger>
@@ -832,6 +943,20 @@ export function PreviewPanel({ graph, className, variant = "overlay", getPropert
                   <SelectItem value="cube">Cube</SelectItem>
                   <SelectItem value="cylinder">Cylinder</SelectItem>
                   {customModel ? <SelectItem value="custom">Model ({customModel.label})</SelectItem> : null}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="min-w-[160px]">
+              <Select value={lightingProfile.id} onValueChange={(value) => { setLightingProfileId(value); setProperty?.("lighting_profile", value); }}>
+                <SelectTrigger aria-label="Lighting profile" title={hasLightingDescription ? lightingDescription : undefined}>
+                  <SelectValue placeholder="Lighting" />
+                </SelectTrigger>
+                <SelectContent>
+                  {lightingProfiles.map((profile) => (
+                    <SelectItem key={profile.id} value={profile.id}>
+                      {profile.label}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>
@@ -910,6 +1035,20 @@ export function PreviewPanel({ graph, className, variant = "overlay", getPropert
                   <SelectItem value="cube">Cube</SelectItem>
                   <SelectItem value="cylinder">Cylinder</SelectItem>
                   {customModel ? <SelectItem value="custom">Model ({customModel.label})</SelectItem> : null}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="min-w-[160px]">
+              <Select value={lightingProfile.id} onValueChange={(value) => { setLightingProfileId(value); setProperty?.("lighting_profile", value); }}>
+                <SelectTrigger aria-label="Lighting profile" title={hasLightingDescription ? lightingDescription : undefined}>
+                  <SelectValue placeholder="Lighting" />
+                </SelectTrigger>
+                <SelectContent>
+                  {lightingProfiles.map((profile) => (
+                    <SelectItem key={profile.id} value={profile.id}>
+                      {profile.label}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>

--- a/src/core/preview/lightingProfiles.ts
+++ b/src/core/preview/lightingProfiles.ts
@@ -1,0 +1,81 @@
+import rawProfiles from "../../../data/preview/lighting_profiles.json";
+
+export type LightingProfileLight = {
+  type: string;
+  position?: [number, number, number];
+  direction?: [number, number, number];
+  color: [number, number, number];
+  intensity: number;
+};
+
+export type LightingProfile = {
+  id: string;
+  label: string;
+  description: string;
+  exposure: number;
+  ambient: [number, number, number];
+  lights: LightingProfileLight[];
+};
+
+function toVector3(value: unknown): [number, number, number] | undefined {
+  if (!Array.isArray(value) || value.length !== 3) return undefined;
+  const [x, y, z] = value;
+  if (typeof x !== "number" || typeof y !== "number" || typeof z !== "number") return undefined;
+  return [x, y, z];
+}
+
+function sanitizeLight(light: any): LightingProfileLight | null {
+  if (!light || typeof light !== "object") return null;
+  const type = typeof light.type === "string" ? light.type : "directional";
+  const position = toVector3(light.position);
+  const direction = toVector3(light.direction);
+  const color = toVector3(light.color) ?? [1, 1, 1];
+  const intensity = typeof light.intensity === "number" && Number.isFinite(light.intensity) ? light.intensity : 1;
+  return { type, position, direction, color, intensity };
+}
+
+function sanitizeProfile(profile: any): LightingProfile | null {
+  if (!profile || typeof profile !== "object") return null;
+  const id = typeof profile.id === "string" && profile.id ? profile.id : null;
+  const label = typeof profile.label === "string" && profile.label ? profile.label : id;
+  if (!id || !label) return null;
+  const description = typeof profile.description === "string" ? profile.description : "";
+  const exposure = typeof profile.exposure === "number" && Number.isFinite(profile.exposure) ? profile.exposure : 1;
+  const ambient = toVector3(profile.ambient) ?? [0.05, 0.05, 0.05];
+  const lightsRaw = Array.isArray(profile.lights) ? profile.lights : [];
+  const lights: LightingProfileLight[] = [];
+  for (const light of lightsRaw) {
+    const sanitized = sanitizeLight(light);
+    if (sanitized) lights.push(sanitized);
+  }
+  return { id, label, description, exposure, ambient, lights };
+}
+
+const parsedProfiles = Array.isArray(rawProfiles) ? rawProfiles.map(sanitizeProfile).filter(Boolean) : [];
+
+if (!parsedProfiles.length) {
+  parsedProfiles.push({
+    id: "default",
+    label: "Default",
+    description: "Fallback preview lighting.",
+    exposure: 1.3,
+    ambient: [0.08, 0.08, 0.08],
+    lights: [
+      { type: "directional", direction: [-0.35, 0.8, 0.6], color: [1, 1, 1], intensity: 3 },
+      { type: "directional", direction: [0.6, 0.2, 0.2], color: [0.8, 0.9, 1], intensity: 1.2 },
+      { type: "directional", direction: [-0.2, 0.3, -0.9], color: [1, 0.9, 1.1], intensity: 2 },
+    ],
+  });
+}
+
+export const lightingProfiles: LightingProfile[] = parsedProfiles as LightingProfile[];
+
+export const DEFAULT_LIGHTING_PROFILE_ID = lightingProfiles[0]?.id ?? "default";
+
+export function getLightingProfile(id: string | null | undefined): LightingProfile {
+  if (id) {
+    const match = lightingProfiles.find((profile) => profile.id === id);
+    if (match) return match;
+  }
+  return lightingProfiles[0];
+}


### PR DESCRIPTION
## Summary
- add curated JSON lighting profile presets and a sanitized loader for the preview
- wire the 3D preview panel to pick lighting profiles, persist them on the node, and drive lighting uniforms accordingly
- expose lighting profile selection in the preview UI and allow importing JSON modules in the toolchain

## Testing
- `bun x tsc -p tsconfig.json --noEmit`
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68e8149875f48332aca1b5c7a6043d27