### PR TITLE
fix: simplify right-click context menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,6 +121,7 @@ const DISTRIBUTION_LABELS: Record<DistributionKind, string> = {
   horizontal: "Distribute Horizontally",
   vertical: "Distribute Vertically",
   "vertical-stack": "Stack Vertically",
+  "horizontal-stack": "Stack Horizontally",
 };
 
 const DUPLICATE_OFFSET = { x: 32, y: 32 };
@@ -2595,7 +2596,8 @@ export function App() {
     (distribution: DistributionKind) => {
       setNodes((prev) => {
         const selected = prev.filter((n) => n.selected);
-        if (selected.length <= 2) return prev;
+        const minSelection = distribution === "vertical-stack" || distribution === "horizontal-stack" ? 2 : 3;
+        if (selected.length < minSelection) return prev;
         const selectedIds = new Set(selected.map((n) => n.id));
         const { nodes: distributedNodes, changed } = distributeSelectedNodes(prev, selectedIds, distribution);
         if (!changed) return prev;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,6 +120,7 @@ const ALIGNMENT_LABELS: Record<AlignmentKind, string> = {
 const DISTRIBUTION_LABELS: Record<DistributionKind, string> = {
   horizontal: "Distribute Horizontally",
   vertical: "Distribute Vertically",
+  "vertical-stack": "Stack Vertically",
 };
 
 const DUPLICATE_OFFSET = { x: 32, y: 32 };
@@ -235,6 +236,7 @@ export function App() {
   const [menuPaletteOverride, setMenuPaletteOverride] = useState<NodePalette | null>(null);
   const [showCompileOnly, setShowCompileOnly] = useState<boolean>(false);
   const [clipboardStatus, setClipboardStatus] = useState<{ kind: "success" | "error"; message: string; key: number } | null>(null);
+  const [canPasteFromClipboard, setCanPasteFromClipboard] = useState(false);
   const [showDocsPanel, setShowDocsPanel] = useState<boolean>(false);
   const [docsWidth, setDocsWidth] = useState<number>(768);
   const docsResizing = useRef(false);
@@ -243,7 +245,6 @@ export function App() {
   const [isDocsResizing, setIsDocsResizing] = useState(false);
   const clipboardStatusTimerRef = useRef<number | null>(null);
   const quickHotkeysPersistReadyRef = useRef(false);
-  const canPasteViaButton = typeof navigator !== "undefined";
   const flowContainerRef = useRef<HTMLDivElement | null>(null);
   const lastPointerRef = useRef<{ x: number; y: number } | null>(null);
   const initialLoadDoneRef = useRef(false);
@@ -2494,6 +2495,35 @@ export function App() {
   }, [performPasteFromText, showClipboardStatus]);
 
   useEffect(() => {
+    if (!menu.open) {
+      setCanPasteFromClipboard(false);
+      return;
+    }
+    if (typeof navigator === "undefined" || typeof navigator.clipboard?.readText !== "function") {
+      setCanPasteFromClipboard(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const text = await navigator.clipboard.readText();
+        if (cancelled) return;
+        if (!text) {
+          setCanPasteFromClipboard(false);
+          return;
+        }
+        parseClipboardPayload(text);
+        setCanPasteFromClipboard(true);
+      } catch (_err) {
+        if (!cancelled) setCanPasteFromClipboard(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [menu.open, menu.kind, menu.targetId]);
+
+  useEffect(() => {
     const handler = (event: KeyboardEvent) => {
       const isMod = event.metaKey || event.ctrlKey;
       if (!isMod || event.altKey || event.shiftKey) return;
@@ -3229,7 +3259,7 @@ export function App() {
                   setMenu((m) => ({ ...m, open: false }));
                   setMenuPaletteOverride(null);
                 }}
-                canPaste={canPasteViaButton}
+                canPaste={canPasteFromClipboard}
                 onAddNode={async (item) => {
                   if (!item) return;
                   await addNodeAt({ item, x: menu.x, y: menu.y });

--- a/src/components/GraphContextMenu.tsx
+++ b/src/components/GraphContextMenu.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Input } from "./ui/input";
@@ -83,6 +90,10 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
   const hasArrangementActions = Boolean(onAlignSelected || onDistributeSelected);
   const arrangementButtonRef = useRef<HTMLButtonElement | null>(null);
   const arrangementPortalRef = useRef<HTMLDivElement | null>(null);
+  const [menuWidth, setMenuWidth] = useState<number | null>(null);
+
+  const baseMenuButtonClasses =
+    "w-full px-2 py-1 text-sm rounded-md text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
 
   const formatCategory = (name: string): string => {
     if (!name) return name;
@@ -182,6 +193,12 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
     };
   }, [arrangementOpen, closeArrangementMenus]);
 
+  useEffect(() => {
+    if (!open) {
+      setMenuWidth(null);
+    }
+  }, [open]);
+
   type VisibleItem =
     | { kind: "category"; key: string }
     | { kind: "node"; key: string; node: NodePaletteItem; parent?: string };
@@ -208,6 +225,22 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
     }
     return items;
   }, [kind, palette, query, expanded]);
+
+  useLayoutEffect(() => {
+    if (!open || !ref.current) return;
+    const card = ref.current;
+    const previousWidth = card.style.width;
+    card.style.width = "auto";
+    const items = Array.from(card.querySelectorAll<HTMLElement>("[data-menu-item=\"true\"]"));
+    const widest = items.reduce((max, el) => Math.max(max, el.offsetWidth), 0);
+    const viewportMax = Math.min(260, window.innerWidth - 16);
+    if (widest > 0) {
+      setMenuWidth(Math.min(Math.ceil(widest * 1.15), viewportMax));
+    } else {
+      setMenuWidth(Math.min(180, viewportMax));
+    }
+    card.style.width = previousWidth;
+  }, [open, kind, visibleItems, selectionSize, canPaste, canUngroup, canAlign, canDistribute, hasArrangementActions]);
 
   // Keep highlight index in range when list changes
   useEffect(() => {
@@ -294,13 +327,12 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
 
   const renderArrangementSection = () => {
     if (!hasArrangementActions) return null;
-    const disabled = !canAlign && !canDistribute;
-    const firstSubmenu: "align" | "distribute" | null = !disabled
-      ? (!canAlign && canDistribute ? "distribute" : canAlign ? "align" : null)
-      : null;
+    const allowAlign = canAlign && Boolean(onAlignSelected);
+    const allowDistribute = canDistribute && Boolean(onDistributeSelected);
+    if (!allowAlign && !allowDistribute) return null;
+    const firstSubmenu: "align" | "distribute" | null = !allowAlign && allowDistribute ? "distribute" : allowAlign ? "align" : null;
 
     const openMenu = (autoSubmenu: boolean) => {
-      if (disabled) return;
       updateArrangementPosition();
       setArrangementOpen(true);
       setActiveArrangementSubmenu(autoSubmenu ? firstSubmenu : null);
@@ -308,22 +340,16 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
     return (
       <button
         ref={arrangementButtonRef}
-        className={cn(
-          "w-full px-2 py-1.5 rounded-md text-sm flex items-center justify-between",
-          disabled && "bg-muted text-muted-foreground cursor-not-allowed",
-          !disabled && arrangementOpen && "bg-accent text-accent-foreground",
-          !disabled && !arrangementOpen && "bg-muted text-foreground hover:bg-accent/80 hover:text-accent-foreground"
-        )}
-        disabled={disabled}
+        className={cn(baseMenuButtonClasses, "flex items-center justify-between")}
+        data-menu-item="true"
         aria-haspopup="true"
-        aria-expanded={arrangementOpen && !disabled}
+        aria-expanded={arrangementOpen}
         onMouseEnter={() => openMenu(false)}
         onFocus={() => openMenu(true)}
         onBlur={closeArrangementIfFocusMoves}
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
-          if (disabled) return;
           if (arrangementOpen) {
             closeArrangementMenus();
           } else {
@@ -345,7 +371,7 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
           style={{ position: "fixed", left: submenuPosition.left, top: submenuPosition.top, zIndex: 60 }}
         >
           <div className="rounded-md border bg-popover text-popover-foreground shadow-lg py-1 min-w-[170px]">
-            {onAlignSelected && (
+            {canAlign && onAlignSelected && (
               <div
                 className="relative"
                 onMouseEnter={() => { if (canAlign) setActiveArrangementSubmenu("align"); }}
@@ -353,34 +379,29 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
               >
                 <button
                   className={cn(
-                    "w-full px-3 py-1.5 text-sm flex items-center justify-between",
-                    !canAlign && "text-muted-foreground cursor-not-allowed",
-                    canAlign && activeArrangementSubmenu === "align" && "bg-accent text-accent-foreground",
-                    canAlign && activeArrangementSubmenu !== "align" && "hover:bg-accent/70 hover:text-accent-foreground"
+                    "w-full px-3 py-1 text-sm flex items-center justify-between rounded-md transition-colors hover:bg-muted",
+                    activeArrangementSubmenu === "align" && "bg-muted"
                   )}
-                  disabled={!canAlign}
                   onMouseEnter={() => { if (canAlign) setActiveArrangementSubmenu("align"); }}
                   onFocus={() => { if (canAlign) setActiveArrangementSubmenu("align"); }}
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
-                    if (!canAlign) return;
                     setActiveArrangementSubmenu("align");
                   }}
                 >
                   <span>Align</span>
                   <ChevronRight className="h-4 w-4" />
                 </button>
-                {canAlign && activeArrangementSubmenu === "align" && (
+                {activeArrangementSubmenu === "align" && (
                   <div className="absolute left-full top-0 ml-1 rounded-md border bg-popover text-popover-foreground shadow-lg py-1 min-w-[150px]">
                     {ALIGNMENT_OPTIONS.map((option) => (
                       <button
                         key={`align:${option.kind}`}
-                        className="w-full px-3 py-1.5 text-sm text-left hover:bg-accent/70 hover:text-accent-foreground"
+                        className="w-full px-3 py-1 text-sm text-left rounded-md transition-colors hover:bg-muted"
                         onClick={(e) => {
                           e.preventDefault();
                           e.stopPropagation();
-                          if (!canAlign) return;
                           onAlignSelected(option.kind);
                           closeArrangementMenus();
                         }}
@@ -392,7 +413,7 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
                 )}
               </div>
             )}
-            {onDistributeSelected && (
+            {canDistribute && onDistributeSelected && (
               <div
                 className="relative"
                 onMouseEnter={() => { if (canDistribute) setActiveArrangementSubmenu("distribute"); }}
@@ -400,34 +421,29 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
               >
                 <button
                   className={cn(
-                    "w-full px-3 py-1.5 text-sm flex items-center justify-between",
-                    !canDistribute && "text-muted-foreground cursor-not-allowed",
-                    canDistribute && activeArrangementSubmenu === "distribute" && "bg-accent text-accent-foreground",
-                    canDistribute && activeArrangementSubmenu !== "distribute" && "hover:bg-accent/70 hover:text-accent-foreground"
+                    "w-full px-3 py-1 text-sm flex items-center justify-between rounded-md transition-colors hover:bg-muted",
+                    activeArrangementSubmenu === "distribute" && "bg-muted"
                   )}
-                  disabled={!canDistribute}
                   onMouseEnter={() => { if (canDistribute) setActiveArrangementSubmenu("distribute"); }}
                   onFocus={() => { if (canDistribute) setActiveArrangementSubmenu("distribute"); }}
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
-                    if (!canDistribute) return;
                     setActiveArrangementSubmenu("distribute");
                   }}
                 >
                   <span>Distribute</span>
                   <ChevronRight className="h-4 w-4" />
                 </button>
-                {canDistribute && activeArrangementSubmenu === "distribute" && (
+                {activeArrangementSubmenu === "distribute" && (
                   <div className="absolute left-full top-0 ml-1 rounded-md border bg-popover text-popover-foreground shadow-lg py-1 min-w-[150px]">
                     {DISTRIBUTION_OPTIONS.map((option) => (
                       <button
                         key={`distribute:${option.kind}`}
-                        className="w-full px-3 py-1.5 text-sm text-left hover:bg-accent/70 hover:text-accent-foreground"
+                        className="w-full px-3 py-1 text-sm text-left rounded-md transition-colors hover:bg-muted"
                         onClick={(e) => {
                           e.preventDefault();
                           e.stopPropagation();
-                          if (!canDistribute) return;
                           onDistributeSelected(option.kind);
                           closeArrangementMenus();
                         }}
@@ -445,6 +461,107 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
       )
     : null;
 
+  const selectionActions: Array<{ key: string; label: string; onSelect: () => void }> = [];
+  if (selectionSize > 0 && onCopySelection) {
+    selectionActions.push({
+      key: "copy-selection",
+      label: `Copy Selection${selectionSize ? ` (${selectionSize})` : ""}`,
+      onSelect: () => onCopySelection(),
+    });
+  }
+  if (canPaste && onPasteFromClipboard) {
+    selectionActions.push({
+      key: "paste",
+      label: "Paste",
+      onSelect: () => onPasteFromClipboard(),
+    });
+  }
+  if (selectionSize > 0 && onDuplicateSelection) {
+    selectionActions.push({
+      key: "duplicate-selection",
+      label: `Duplicate Selection${selectionSize ? ` (${selectionSize})` : ""}`,
+      onSelect: () => onDuplicateSelection(),
+    });
+  }
+  if (selectionSize > 0 && onGroupSelected) {
+    selectionActions.push({
+      key: "group-selection",
+      label: `Group Selected${selectionSize ? ` (${selectionSize})` : ""}`,
+      onSelect: () => onGroupSelected(),
+    });
+  }
+
+  const nodeActions: Array<{ key: string; label: string; onSelect: () => void }> = [];
+  if (targetId && onCopySelection) {
+    nodeActions.push({
+      key: "copy-node",
+      label: "Copy Node",
+      onSelect: () => onCopySelection(targetId),
+    });
+  }
+  if (targetId && onDuplicateSelection) {
+    nodeActions.push({
+      key: "duplicate-node",
+      label: "Duplicate Node",
+      onSelect: () => onDuplicateSelection(targetId),
+    });
+  }
+  if (targetId && canUngroup && onUngroupNode) {
+    nodeActions.push({
+      key: "ungroup-node",
+      label: "Ungroup",
+      onSelect: () => onUngroupNode(targetId),
+    });
+  }
+  if (selectionSize > 0 && onGroupSelected) {
+    nodeActions.push({
+      key: "group-from-node",
+      label: `Group Selected${selectionSize ? ` (${selectionSize})` : ""}`,
+      onSelect: () => onGroupSelected(),
+    });
+  }
+  if (canPaste && onPasteFromClipboard) {
+    nodeActions.push({
+      key: "paste-node",
+      label: "Paste",
+      onSelect: () => onPasteFromClipboard(),
+    });
+  }
+  if (targetId && onDeleteNode) {
+    nodeActions.push({
+      key: "delete-node",
+      label: "Delete Node",
+      onSelect: () => onDeleteNode(targetId),
+    });
+  }
+
+  const edgeActions: Array<{ key: string; label: string; onSelect: () => void }> = [];
+  if (canPaste && onPasteFromClipboard) {
+    edgeActions.push({
+      key: "paste-edge",
+      label: "Paste",
+      onSelect: () => onPasteFromClipboard(),
+    });
+  }
+
+  const renderActionButtons = (actions: Array<{ key: string; label: string; onSelect: () => void }>) =>
+    actions.map((action) => (
+      <button
+        key={action.key}
+        className={baseMenuButtonClasses}
+        data-menu-item="true"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          action.onSelect();
+        }}
+      >
+        {action.label}
+      </button>
+    ));
+
+  const arrangementContent = renderArrangementSection();
+
   if (!open) return null;
 
   // Basic size & placement logic; clamp within viewport
@@ -452,7 +569,8 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
   const vh = window.innerHeight;
   const maxW = Math.min(260, vw - 16);
   const maxH = Math.min(420, vh - 16);
-  const posX = Math.min(x, vw - maxW - 8);
+  const desiredWidth = menuWidth ? Math.min(menuWidth, maxW) : Math.min(220, maxW);
+  const posX = Math.min(x, vw - desiredWidth - 8);
   const posY = Math.min(y, vh - maxH - 8);
 
   return (
@@ -464,12 +582,12 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
         <Card
           ref={ref}
           className="pointer-events-auto shadow-lg border bg-popover text-popover-foreground"
-          style={{ position: "fixed", left: posX, top: posY, width: maxW, maxHeight: maxH, overflow: "auto" }}
+          style={{ position: "fixed", left: posX, top: posY, width: desiredWidth, maxHeight: maxH, overflow: "auto" }}
           role="menu"
           aria-label="Graph context menu"
         >
           {kind !== "background" && (
-            <CardHeader className="py-2 px-3">
+            <CardHeader className="py-1.5 px-2">
               <CardTitle className="text-sm">
                 {kind === "selection" && `Selection • ${selectedCount ?? 0} nodes`}
                 {kind === "node" && `Node • ${targetId ?? "(unknown)"}`}
@@ -477,7 +595,7 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
               </CardTitle>
             </CardHeader>
           )}
-          <CardContent className="flex flex-col gap-1 p-3">
+          <CardContent className="flex flex-col gap-2 p-2">
             {kind === "background" ? (
               <>
                 <Input
@@ -485,13 +603,13 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
                   autoFocus
-                  className="h-8 text-sm"
+                  className="h-8 w-full text-sm"
                 />
                 <div className="flex flex-col gap-1">
                   {visibleItems.length === 0 && (
                     <div className="text-muted-foreground text-sm">No nodes found</div>
                   )}
-                  <ul className="flex flex-col">
+                  <ul className="flex flex-col gap-0.5">
                     {visibleItems.map((it, idx) => {
                     if (it.kind === "category") {
                       const isOpen = expanded.has(it.key);
@@ -500,11 +618,12 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
                           key={`cat:${it.key}`}
                           ref={(el) => { itemRefs.current[idx] = el; }}
                           className={cn(
-                            "px-2 py-1 rounded-md cursor-pointer select-none flex items-center justify-between",
-                            idx === highlightIndex && "bg-accent text-accent-foreground"
+                            "px-2 py-1 rounded-md cursor-pointer select-none flex items-center justify-between transition-colors hover:bg-muted",
+                            idx === highlightIndex && "bg-muted"
                           )}
                           role="menuitem"
                           aria-selected={idx === highlightIndex}
+                          data-menu-item="true"
                           onMouseEnter={() => setHighlightIndex(idx)}
                           onClick={(e) => {
                             e.preventDefault();
@@ -517,7 +636,7 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
                             });
                           }}
                         >
-                          <span className="text-sm font-semibold">{formatCategory(it.key)}</span>
+                          <span className="text-sm font-medium">{formatCategory(it.key)}</span>
                           {isOpen ? (
                             <ChevronDown className="h-4 w-4 opacity-70" />
                           ) : (
@@ -532,11 +651,12 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
                         key={`node:${it.key}`}
                         ref={(el) => { itemRefs.current[idx] = el; }}
                         className={cn(
-                          "pl-6 pr-2 py-1 rounded-md cursor-pointer hover:bg-accent/80 hover:text-accent-foreground select-none",
-                          idx === highlightIndex && "bg-accent text-accent-foreground"
+                          "pl-6 pr-2 py-1 rounded-md cursor-pointer select-none transition-colors hover:bg-muted",
+                          idx === highlightIndex && "bg-muted"
                         )}
                         role="menuitem"
                         aria-selected={idx === highlightIndex}
+                        data-menu-item="true"
                         onMouseEnter={() => setHighlightIndex(idx)}
                         onClick={(e) => {
                           e.preventDefault();
@@ -555,180 +675,27 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
                 </div>
               </>
             ) : kind === "selection" ? (
-              <div className="flex flex-col gap-3">
-                <button
-                  className={cn(
-                    "px-2 py-1.5 rounded-md text-sm",
-                    selectedCount && selectedCount > 0
-                      ? "bg-primary/10 text-primary hover:bg-primary/15"
-                      : "bg-muted text-muted-foreground cursor-not-allowed"
-                  )}
-                  disabled={!selectedCount || selectedCount <= 0}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (selectedCount && selectedCount > 0 && onCopySelection) onCopySelection();
-                  }}
-                >
-                  Copy Selection{selectedCount ? ` (${selectedCount})` : ""}
-                </button>
-                <button
-                  className={cn(
-                    "px-2 py-1.5 rounded-md text-sm",
-                    canPaste
-                      ? "bg-primary/10 text-primary hover:bg-primary/15"
-                      : "bg-muted text-muted-foreground cursor-not-allowed"
-                  )}
-                  disabled={!canPaste}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (canPaste && onPasteFromClipboard) onPasteFromClipboard();
-                  }}
-                >
-                  Paste
-                </button>
-                <button
-                  className={cn(
-                    "px-2 py-1.5 rounded-md text-sm",
-                    selectedCount && selectedCount > 0
-                      ? "bg-primary/10 text-primary hover:bg-primary/15"
-                      : "bg-muted text-muted-foreground cursor-not-allowed"
-                  )}
-                  disabled={!selectedCount || selectedCount <= 0}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (selectedCount && selectedCount > 0 && onDuplicateSelection) onDuplicateSelection();
-                  }}
-                >
-                  Duplicate Selection{selectedCount ? ` (${selectedCount})` : ""}
-                </button>
-                <button
-                  className={cn(
-                    "px-2 py-1.5 rounded-md text-sm",
-                    selectedCount && selectedCount > 0
-                      ? "bg-primary/10 text-primary hover:bg-primary/15"
-                      : "bg-muted text-muted-foreground cursor-not-allowed"
-                  )}
-                  disabled={!selectedCount || selectedCount <= 0}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (selectedCount && selectedCount > 0 && onGroupSelected) onGroupSelected();
-                  }}
-                >
-                  Group Selected{selectedCount ? ` (${selectedCount})` : ""}
-                </button>
-                {renderArrangementSection()}
+              <div className="flex flex-col gap-1">
+                {renderActionButtons(selectionActions)}
+                {arrangementContent}
+                {!selectionActions.length && !arrangementContent && (
+                  <div className="text-sm text-muted-foreground">No actions available</div>
+                )}
               </div>
             ) : kind === "node" ? (
-              <div className="flex flex-col gap-2">
-                <button
-                  className={cn(
-                    "px-2 py-1.5 rounded-md text-sm",
-                    onCopySelection ? "bg-primary/10 text-primary hover:bg-primary/15" : "bg-muted text-muted-foreground cursor-not-allowed"
-                  )}
-                  disabled={!onCopySelection}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (onCopySelection) onCopySelection(targetId);
-                  }}
-                >
-                  Copy Node
-                </button>
-                <button
-                  className={cn(
-                    "px-2 py-1.5 rounded-md text-sm",
-                    onDuplicateSelection ? "bg-primary/10 text-primary hover:bg-primary/15" : "bg-muted text-muted-foreground cursor-not-allowed"
-                  )}
-                  disabled={!onDuplicateSelection}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (onDuplicateSelection && targetId) onDuplicateSelection(targetId);
-                  }}
-                >
-                  Duplicate Node
-                </button>
-                <button
-                  className={cn(
-                    "px-2 py-1.5 rounded-md text-sm",
-                    canUngroup
-                      ? "bg-primary/10 text-primary hover:bg-primary/15"
-                      : "bg-muted text-muted-foreground cursor-not-allowed"
-                  )}
-                  disabled={!canUngroup}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (canUngroup && targetId && onUngroupNode) onUngroupNode(targetId);
-                  }}
-                >
-                  Ungroup
-                </button>
-                <button
-                  className={cn(
-                    "px-2 py-1.5 rounded-md text-sm",
-                    selectedCount && selectedCount > 0
-                      ? "bg-primary/10 text-primary hover:bg-primary/15"
-                      : "bg-muted text-muted-foreground cursor-not-allowed"
-                  )}
-                  disabled={!selectedCount || selectedCount <= 0}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (selectedCount && selectedCount > 0 && onGroupSelected) onGroupSelected();
-                  }}
-                >
-                  Group Selected{selectedCount ? ` (${selectedCount})` : ""}
-                </button>
-                {renderArrangementSection()}
-                <button
-                  className={cn(
-                    "px-2 py-1.5 rounded-md text-sm",
-                    canPaste ? "bg-primary/10 text-primary hover:bg-primary/15" : "bg-muted text-muted-foreground cursor-not-allowed"
-                  )}
-                  disabled={!canPaste}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (canPaste && onPasteFromClipboard) onPasteFromClipboard();
-                  }}
-                >
-                  Paste
-                </button>
-                <button
-                  className="px-2 py-1.5 rounded-md bg-destructive/10 text-destructive text-sm hover:bg-destructive/20"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (targetId && onDeleteNode) onDeleteNode(targetId);
-                  }}
-                >
-                  Delete Node
-                </button>
+              <div className="flex flex-col gap-1">
+                {renderActionButtons(nodeActions)}
+                {arrangementContent}
+                {!nodeActions.length && !arrangementContent && (
+                  <div className="text-sm text-muted-foreground">No actions available</div>
+                )}
               </div>
             ) : (
-              <div className="flex flex-col gap-2">
-                <button
-                  className={cn(
-                    "px-2 py-1.5 rounded-md text-sm",
-                    onPasteFromClipboard && canPaste
-                      ? "bg-primary/10 text-primary hover:bg-primary/15"
-                      : "bg-muted text-muted-foreground cursor-not-allowed"
-                  )}
-                  disabled={!onPasteFromClipboard || !canPaste}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (onPasteFromClipboard) onPasteFromClipboard();
-                  }}
-                >
-                  Paste
-                </button>
-                <div className="text-sm text-muted-foreground">Select nodes to enable more actions</div>
+              <div className="flex flex-col gap-1">
+                {renderActionButtons(edgeActions)}
+                {!edgeActions.length && (
+                  <div className="text-sm text-muted-foreground">Select nodes to enable more actions</div>
+                )}
               </div>
             )}
           </CardContent>

--- a/src/components/GraphContextMenu.tsx
+++ b/src/components/GraphContextMenu.tsx
@@ -52,6 +52,7 @@ const DISTRIBUTION_OPTIONS: Array<{ kind: DistributionKind; label: string }> = [
   { kind: "horizontal", label: "Horizontal" },
   { kind: "vertical", label: "Vertical" },
   { kind: "vertical-stack", label: "Vertical Stack" },
+  { kind: "horizontal-stack", label: "Horizontal Stack" },
 ];
 
 export function GraphContextMenu(props: GraphContextMenuProps) {
@@ -84,7 +85,15 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
   const itemRefs = useRef<Array<HTMLLIElement | null>>([]);
   const selectionSize = selectedCount ?? 0;
   const canAlign = selectionSize >= 2 && Boolean(onAlignSelected);
-  const canDistribute = selectionSize >= 3 && Boolean(onDistributeSelected);
+  const visibleDistributionOptions = useMemo(() => {
+    return DISTRIBUTION_OPTIONS.filter((option) => {
+      if (option.kind === "vertical-stack" || option.kind === "horizontal-stack") {
+        return selectionSize >= 2;
+      }
+      return selectionSize >= 3;
+    });
+  }, [selectionSize]);
+  const canDistribute = visibleDistributionOptions.length > 0 && Boolean(onDistributeSelected);
   const [arrangementOpen, setArrangementOpen] = useState(false);
   const [activeArrangementSubmenu, setActiveArrangementSubmenu] = useState<"align" | "distribute" | null>(null);
   const [submenuPosition, setSubmenuPosition] = useState<{ left: number; top: number }>({ left: 0, top: 0 });
@@ -438,7 +447,7 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
                 </button>
                 {activeArrangementSubmenu === "distribute" && (
                   <div className="absolute left-full top-0 ml-1 rounded-md border bg-popover text-popover-foreground shadow-lg py-1 min-w-[150px]">
-                    {DISTRIBUTION_OPTIONS.map((option) => (
+                    {visibleDistributionOptions.map((option) => (
                       <button
                         key={`distribute:${option.kind}`}
                         className="w-full px-3 py-1 text-sm text-left rounded-md transition-colors hover:bg-muted"

--- a/src/components/GraphContextMenu.tsx
+++ b/src/components/GraphContextMenu.tsx
@@ -51,6 +51,7 @@ const ALIGNMENT_OPTIONS: Array<{ kind: AlignmentKind; label: string }> = [
 const DISTRIBUTION_OPTIONS: Array<{ kind: DistributionKind; label: string }> = [
   { kind: "horizontal", label: "Horizontal" },
   { kind: "vertical", label: "Vertical" },
+  { kind: "vertical-stack", label: "Vertical Stack" },
 ];
 
 export function GraphContextMenu(props: GraphContextMenuProps) {

--- a/src/core/ui/__tests__/arrange.test.ts
+++ b/src/core/ui/__tests__/arrange.test.ts
@@ -148,12 +148,32 @@ describe("distributeSelectedNodes", () => {
     const a = stacked.find((n) => n.id === "a")!;
     const b = stacked.find((n) => n.id === "b")!;
     const c = stacked.find((n) => n.id === "c")!;
+    const minX = Math.min(...nodes.map((n) => n.position.x));
     expect(b.position.y).toBeCloseTo(10, 4);
-    expect(a.position.y).toBeCloseTo((b.position.y + (b.height ?? 0) + 1), 4);
-    expect(c.position.y).toBeCloseTo((a.position.y + (a.height ?? 0) + 1), 4);
-    expect(a.position.x).toBe(0);
-    expect(b.position.x).toBe(40);
-    expect(c.position.x).toBe(-10);
+    expect(a.position.y).toBeCloseTo(b.position.y + (b.height ?? 0) + 1, 4);
+    expect(c.position.y).toBeCloseTo(a.position.y + (a.height ?? 0) + 1, 4);
+    expect(a.position.x).toBe(minX);
+    expect(b.position.x).toBe(minX);
+    expect(c.position.x).toBe(minX);
+  });
+
+  it("stacks nodes horizontally with a 1px gap", () => {
+    const nodes = [
+      makeNode("a", { x: 0, y: 0 }, { width: 40, height: 40 }),
+      makeNode("b", { x: 120, y: 20 }, { width: 60, height: 60 }),
+      makeNode("c", { x: 260, y: -10 }, { width: 30, height: 30 }),
+    ];
+    const selection = new Set(["a", "b", "c"]);
+    const { nodes: stacked } = distributeSelectedNodes(nodes, selection, "horizontal-stack");
+    const a = stacked.find((n) => n.id === "a")!;
+    const b = stacked.find((n) => n.id === "b")!;
+    const c = stacked.find((n) => n.id === "c")!;
+    const minY = Math.min(...nodes.map((n) => n.position.y));
+    expect(a.position.y).toBe(minY);
+    expect(b.position.y).toBe(minY);
+    expect(c.position.y).toBe(minY);
+    expect(b.position.x).toBeCloseTo(a.position.x + (a.width ?? 0) + 1, 4);
+    expect(c.position.x).toBeCloseTo(b.position.x + (b.width ?? 0) + 1, 4);
   });
 
   it("does nothing when fewer than three nodes are selected", () => {
@@ -165,6 +185,35 @@ describe("distributeSelectedNodes", () => {
     const result = distributeSelectedNodes(nodes, selection, "horizontal");
     expect(result.changed).toBe(false);
     expect(result.nodes).toBe(nodes);
+  });
+
+  it("stacks two nodes when only a pair is selected", () => {
+    const nodes = [
+      makeNode("1", { x: 0, y: 0 }, { width: 40, height: 40 }),
+      makeNode("2", { x: 100, y: 80 }, { width: 60, height: 50 }),
+    ];
+    const selection = new Set(["1", "2"]);
+    const { nodes: verticalStacked } = distributeSelectedNodes(nodes, selection, "vertical-stack");
+    expect(verticalStacked.find((n) => n.id === "1")?.position.x).toBeCloseTo(
+      verticalStacked.find((n) => n.id === "2")?.position.x ?? 0,
+      4
+    );
+    expect(
+      (verticalStacked.find((n) => n.id === "2")?.position.y ?? 0) -
+        (verticalStacked.find((n) => n.id === "1")?.position.y ?? 0) -
+        ((verticalStacked.find((n) => n.id === "1")?.height ?? 0))
+    ).toBeCloseTo(1, 4);
+
+    const { nodes: horizontalStacked } = distributeSelectedNodes(nodes, selection, "horizontal-stack");
+    expect(horizontalStacked.find((n) => n.id === "1")?.position.y).toBeCloseTo(
+      horizontalStacked.find((n) => n.id === "2")?.position.y ?? 0,
+      4
+    );
+    expect(
+      (horizontalStacked.find((n) => n.id === "2")?.position.x ?? 0) -
+        (horizontalStacked.find((n) => n.id === "1")?.position.x ?? 0) -
+        ((horizontalStacked.find((n) => n.id === "1")?.width ?? 0))
+    ).toBeCloseTo(1, 4);
   });
 
   it("distributes nodes with zero widths similar to measured ReactFlow nodes", () => {

--- a/src/core/ui/__tests__/arrange.test.ts
+++ b/src/core/ui/__tests__/arrange.test.ts
@@ -14,6 +14,10 @@ function makeNode(id: string, position: { x: number; y: number }, options: {
   height?: number;
   parentId?: string;
   positionAbsolute?: { x: number; y: number };
+  style?: { width?: number; height?: number };
+  measured?: { width?: number; height?: number };
+  dimensions?: { width?: number; height?: number };
+  templateMeta?: string[];
 } = {}): TestNode {
   const base: TestNode = {
     id,
@@ -25,6 +29,18 @@ function makeNode(id: string, position: { x: number; y: number }, options: {
   };
   if (options.parentId) base.parentId = options.parentId;
   if (options.positionAbsolute) base.positionAbsolute = options.positionAbsolute as any;
+  if (options.style) base.style = options.style as any;
+  if (options.measured) (base as any).measured = options.measured;
+  if (options.dimensions) (base as any).dimensions = options.dimensions;
+  if (options.templateMeta) {
+    base.data = {
+      ...base.data,
+      template: {
+        ...(base.data?.template ?? {}),
+        meta: [...options.templateMeta],
+      },
+    } as any;
+  }
   return base;
 }
 
@@ -214,6 +230,46 @@ describe("distributeSelectedNodes", () => {
         (horizontalStacked.find((n) => n.id === "1")?.position.x ?? 0) -
         ((horizontalStacked.find((n) => n.id === "1")?.width ?? 0))
     ).toBeCloseTo(1, 4);
+  });
+
+  it("uses measured dimensions when stacking nodes without width/height", () => {
+    const nodes = [
+      makeNode("a", { x: 10, y: 0 }, { measured: { width: 80, height: 60 } }),
+      makeNode("b", { x: 40, y: 140 }, { measured: { width: 70, height: 50 } }),
+    ];
+    const selection = new Set(["a", "b"]);
+    const { nodes: verticalStacked } = distributeSelectedNodes(nodes, selection, "vertical-stack");
+    const a = verticalStacked.find((n) => n.id === "a")!;
+    const b = verticalStacked.find((n) => n.id === "b")!;
+    expect(a.position.x).toBeCloseTo(10, 4);
+    expect(b.position.x).toBeCloseTo(10, 4);
+    expect(b.position.y).toBeCloseTo(a.position.y + ((nodes[0] as any).measured.height ?? 0) + 1, 4);
+
+    const { nodes: horizontalStacked } = distributeSelectedNodes(nodes, selection, "horizontal-stack");
+    const first = horizontalStacked.find((n) => n.id === "a")!;
+    const second = horizontalStacked.find((n) => n.id === "b")!;
+    expect(first.position.y).toBeCloseTo(second.position.y, 4);
+    expect(second.position.x).toBeCloseTo(first.position.x + ((nodes[0] as any).measured.width ?? 0) + 1, 4);
+  });
+
+  it("falls back to editor size metadata when stacking editor panels", () => {
+    const nodes = [
+      makeNode("panel-1", { x: 0, y: 20 }, { templateMeta: ["editor_node", "editor_size:200x150"] }),
+      makeNode("panel-2", { x: 300, y: 200 }, { templateMeta: ["editor_node", "editor_size:180x120"] }),
+    ];
+    const selection = new Set(["panel-1", "panel-2"]);
+    const { nodes: horizontalStacked } = distributeSelectedNodes(nodes, selection, "horizontal-stack");
+    const first = horizontalStacked.find((n) => n.id === "panel-1")!;
+    const second = horizontalStacked.find((n) => n.id === "panel-2")!;
+    expect(first.position.y).toBeCloseTo(20, 4);
+    expect(second.position.y).toBeCloseTo(20, 4);
+    expect(second.position.x).toBeCloseTo(first.position.x + 200 + 1, 4);
+
+    const { nodes: verticalStacked } = distributeSelectedNodes(nodes, selection, "vertical-stack");
+    const top = verticalStacked.find((n) => n.id === "panel-1")!;
+    const bottom = verticalStacked.find((n) => n.id === "panel-2")!;
+    expect(top.position.x).toBeCloseTo(bottom.position.x, 4);
+    expect(bottom.position.y).toBeCloseTo(top.position.y + 150 + 1, 4);
   });
 
   it("distributes nodes with zero widths similar to measured ReactFlow nodes", () => {

--- a/src/core/ui/__tests__/arrange.test.ts
+++ b/src/core/ui/__tests__/arrange.test.ts
@@ -153,7 +153,7 @@ describe("distributeSelectedNodes", () => {
     expect(firstGap).toBeCloseTo(secondGap, 4);
   });
 
-  it("stacks nodes vertically with a 1px gap", () => {
+  it("stacks nodes vertically with a 5px gap", () => {
     const nodes = [
       makeNode("a", { x: 0, y: 50 }, { width: 40, height: 20 }),
       makeNode("b", { x: 40, y: 10 }, { width: 40, height: 60 }),
@@ -166,14 +166,14 @@ describe("distributeSelectedNodes", () => {
     const c = stacked.find((n) => n.id === "c")!;
     const minX = Math.min(...nodes.map((n) => n.position.x));
     expect(b.position.y).toBeCloseTo(10, 4);
-    expect(a.position.y).toBeCloseTo(b.position.y + (b.height ?? 0) + 1, 4);
-    expect(c.position.y).toBeCloseTo(a.position.y + (a.height ?? 0) + 1, 4);
+    expect(a.position.y).toBeCloseTo(b.position.y + (b.height ?? 0) + 5, 4);
+    expect(c.position.y).toBeCloseTo(a.position.y + (a.height ?? 0) + 5, 4);
     expect(a.position.x).toBe(minX);
     expect(b.position.x).toBe(minX);
     expect(c.position.x).toBe(minX);
   });
 
-  it("stacks nodes horizontally with a 15px gap", () => {
+  it("stacks nodes horizontally with a 25px gap", () => {
     const nodes = [
       makeNode("a", { x: 0, y: 0 }, { width: 40, height: 40 }),
       makeNode("b", { x: 120, y: 20 }, { width: 60, height: 60 }),
@@ -188,8 +188,8 @@ describe("distributeSelectedNodes", () => {
     expect(a.position.y).toBe(minY);
     expect(b.position.y).toBe(minY);
     expect(c.position.y).toBe(minY);
-    expect(b.position.x).toBeCloseTo(a.position.x + (a.width ?? 0) + 15, 4);
-    expect(c.position.x).toBeCloseTo(b.position.x + (b.width ?? 0) + 15, 4);
+    expect(b.position.x).toBeCloseTo(a.position.x + (a.width ?? 0) + 25, 4);
+    expect(c.position.x).toBeCloseTo(b.position.x + (b.width ?? 0) + 25, 4);
   });
 
   it("does nothing when fewer than three nodes are selected", () => {
@@ -218,7 +218,7 @@ describe("distributeSelectedNodes", () => {
       (verticalStacked.find((n) => n.id === "2")?.position.y ?? 0) -
         (verticalStacked.find((n) => n.id === "1")?.position.y ?? 0) -
         ((verticalStacked.find((n) => n.id === "1")?.height ?? 0))
-    ).toBeCloseTo(1, 4);
+    ).toBeCloseTo(5, 4);
 
     const { nodes: horizontalStacked } = distributeSelectedNodes(nodes, selection, "horizontal-stack");
     expect(horizontalStacked.find((n) => n.id === "1")?.position.y).toBeCloseTo(
@@ -229,7 +229,7 @@ describe("distributeSelectedNodes", () => {
       (horizontalStacked.find((n) => n.id === "2")?.position.x ?? 0) -
         (horizontalStacked.find((n) => n.id === "1")?.position.x ?? 0) -
         ((horizontalStacked.find((n) => n.id === "1")?.width ?? 0))
-    ).toBeCloseTo(15, 4);
+    ).toBeCloseTo(25, 4);
   });
 
   it("uses measured dimensions when stacking nodes without width/height", () => {
@@ -243,13 +243,13 @@ describe("distributeSelectedNodes", () => {
     const b = verticalStacked.find((n) => n.id === "b")!;
     expect(a.position.x).toBeCloseTo(10, 4);
     expect(b.position.x).toBeCloseTo(10, 4);
-    expect(b.position.y).toBeCloseTo(a.position.y + ((nodes[0] as any).measured.height ?? 0) + 1, 4);
+    expect(b.position.y).toBeCloseTo(a.position.y + ((nodes[0] as any).measured.height ?? 0) + 5, 4);
 
     const { nodes: horizontalStacked } = distributeSelectedNodes(nodes, selection, "horizontal-stack");
     const first = horizontalStacked.find((n) => n.id === "a")!;
     const second = horizontalStacked.find((n) => n.id === "b")!;
     expect(first.position.y).toBeCloseTo(second.position.y, 4);
-    expect(second.position.x).toBeCloseTo(first.position.x + ((nodes[0] as any).measured.width ?? 0) + 15, 4);
+    expect(second.position.x).toBeCloseTo(first.position.x + ((nodes[0] as any).measured.width ?? 0) + 25, 4);
   });
 
   it("falls back to editor size metadata when stacking editor panels", () => {
@@ -263,13 +263,13 @@ describe("distributeSelectedNodes", () => {
     const second = horizontalStacked.find((n) => n.id === "panel-2")!;
     expect(first.position.y).toBeCloseTo(20, 4);
     expect(second.position.y).toBeCloseTo(20, 4);
-    expect(second.position.x).toBeCloseTo(first.position.x + 200 + 15, 4);
+    expect(second.position.x).toBeCloseTo(first.position.x + 200 + 25, 4);
 
     const { nodes: verticalStacked } = distributeSelectedNodes(nodes, selection, "vertical-stack");
     const top = verticalStacked.find((n) => n.id === "panel-1")!;
     const bottom = verticalStacked.find((n) => n.id === "panel-2")!;
     expect(top.position.x).toBeCloseTo(bottom.position.x, 4);
-    expect(bottom.position.y).toBeCloseTo(top.position.y + 150 + 1, 4);
+    expect(bottom.position.y).toBeCloseTo(top.position.y + 150 + 5, 4);
   });
 
   it("distributes nodes with zero widths similar to measured ReactFlow nodes", () => {

--- a/src/core/ui/__tests__/arrange.test.ts
+++ b/src/core/ui/__tests__/arrange.test.ts
@@ -173,7 +173,7 @@ describe("distributeSelectedNodes", () => {
     expect(c.position.x).toBe(minX);
   });
 
-  it("stacks nodes horizontally with a 1px gap", () => {
+  it("stacks nodes horizontally with a 15px gap", () => {
     const nodes = [
       makeNode("a", { x: 0, y: 0 }, { width: 40, height: 40 }),
       makeNode("b", { x: 120, y: 20 }, { width: 60, height: 60 }),
@@ -188,8 +188,8 @@ describe("distributeSelectedNodes", () => {
     expect(a.position.y).toBe(minY);
     expect(b.position.y).toBe(minY);
     expect(c.position.y).toBe(minY);
-    expect(b.position.x).toBeCloseTo(a.position.x + (a.width ?? 0) + 1, 4);
-    expect(c.position.x).toBeCloseTo(b.position.x + (b.width ?? 0) + 1, 4);
+    expect(b.position.x).toBeCloseTo(a.position.x + (a.width ?? 0) + 15, 4);
+    expect(c.position.x).toBeCloseTo(b.position.x + (b.width ?? 0) + 15, 4);
   });
 
   it("does nothing when fewer than three nodes are selected", () => {
@@ -229,7 +229,7 @@ describe("distributeSelectedNodes", () => {
       (horizontalStacked.find((n) => n.id === "2")?.position.x ?? 0) -
         (horizontalStacked.find((n) => n.id === "1")?.position.x ?? 0) -
         ((horizontalStacked.find((n) => n.id === "1")?.width ?? 0))
-    ).toBeCloseTo(1, 4);
+    ).toBeCloseTo(15, 4);
   });
 
   it("uses measured dimensions when stacking nodes without width/height", () => {
@@ -249,7 +249,7 @@ describe("distributeSelectedNodes", () => {
     const first = horizontalStacked.find((n) => n.id === "a")!;
     const second = horizontalStacked.find((n) => n.id === "b")!;
     expect(first.position.y).toBeCloseTo(second.position.y, 4);
-    expect(second.position.x).toBeCloseTo(first.position.x + ((nodes[0] as any).measured.width ?? 0) + 1, 4);
+    expect(second.position.x).toBeCloseTo(first.position.x + ((nodes[0] as any).measured.width ?? 0) + 15, 4);
   });
 
   it("falls back to editor size metadata when stacking editor panels", () => {
@@ -263,7 +263,7 @@ describe("distributeSelectedNodes", () => {
     const second = horizontalStacked.find((n) => n.id === "panel-2")!;
     expect(first.position.y).toBeCloseTo(20, 4);
     expect(second.position.y).toBeCloseTo(20, 4);
-    expect(second.position.x).toBeCloseTo(first.position.x + 200 + 1, 4);
+    expect(second.position.x).toBeCloseTo(first.position.x + 200 + 15, 4);
 
     const { nodes: verticalStacked } = distributeSelectedNodes(nodes, selection, "vertical-stack");
     const top = verticalStacked.find((n) => n.id === "panel-1")!;

--- a/src/core/ui/__tests__/arrange.test.ts
+++ b/src/core/ui/__tests__/arrange.test.ts
@@ -137,6 +137,25 @@ describe("distributeSelectedNodes", () => {
     expect(firstGap).toBeCloseTo(secondGap, 4);
   });
 
+  it("stacks nodes vertically with a 1px gap", () => {
+    const nodes = [
+      makeNode("a", { x: 0, y: 50 }, { width: 40, height: 20 }),
+      makeNode("b", { x: 40, y: 10 }, { width: 40, height: 60 }),
+      makeNode("c", { x: -10, y: 90 }, { width: 40, height: 30 }),
+    ];
+    const selection = new Set(["a", "b", "c"]);
+    const { nodes: stacked } = distributeSelectedNodes(nodes, selection, "vertical-stack");
+    const a = stacked.find((n) => n.id === "a")!;
+    const b = stacked.find((n) => n.id === "b")!;
+    const c = stacked.find((n) => n.id === "c")!;
+    expect(b.position.y).toBeCloseTo(10, 4);
+    expect(a.position.y).toBeCloseTo((b.position.y + (b.height ?? 0) + 1), 4);
+    expect(c.position.y).toBeCloseTo((a.position.y + (a.height ?? 0) + 1), 4);
+    expect(a.position.x).toBe(0);
+    expect(b.position.x).toBe(40);
+    expect(c.position.x).toBe(-10);
+  });
+
   it("does nothing when fewer than three nodes are selected", () => {
     const nodes = [
       makeNode("1", { x: 0, y: 0 }, { width: 50, height: 50 }),

--- a/src/core/ui/arrange.ts
+++ b/src/core/ui/arrange.ts
@@ -1,4 +1,5 @@
 import type { Node, XYPosition } from "@xyflow/react";
+import { parseEditorSize } from "./nodeFactory";
 
 export type AlignmentKind = "left" | "center" | "right" | "top" | "middle" | "bottom";
 export type DistributionKind = "horizontal" | "vertical" | "vertical-stack" | "horizontal-stack";
@@ -38,10 +39,42 @@ function computeAbsoluteOffset(node: Node): XYPosition | undefined {
   return { x: abs.x - position.x, y: abs.y - position.y };
 }
 
+function readNumericDimension(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return null;
+}
+
+function readNodeDimension(node: Node, key: "width" | "height", fallback?: number): number {
+  const anyNode = node as any;
+  const candidates: unknown[] = [
+    anyNode?.measured?.[key],
+    anyNode?.dimensions?.[key],
+    anyNode?.style?.[key],
+    anyNode?.[key],
+    fallback,
+  ];
+  for (const candidate of candidates) {
+    const numeric = readNumericDimension(candidate);
+    if (numeric !== null) return numeric;
+  }
+  return 0;
+}
+
 function collectMetrics(selected: Node[]): NodeMetric[] {
   return selected.map((node) => {
-    const width = Number.isFinite((node as any).width) ? Number((node as any).width) : 0;
-    const height = Number.isFinite((node as any).height) ? Number((node as any).height) : 0;
+    const meta = (() => {
+      const templateMeta = (node.data as any)?.template?.meta;
+      return Array.isArray(templateMeta) ? (templateMeta as string[]) : undefined;
+    })();
+    const { width: metaWidth, height: metaHeight } = parseEditorSize(meta);
+    const width = readNodeDimension(node, "width", metaWidth);
+    const height = readNodeDimension(node, "height", metaHeight);
     const position = node.position ?? { x: 0, y: 0 };
     const left = position.x;
     const top = position.y;

--- a/src/core/ui/arrange.ts
+++ b/src/core/ui/arrange.ts
@@ -1,7 +1,7 @@
 import type { Node, XYPosition } from "@xyflow/react";
 
 export type AlignmentKind = "left" | "center" | "right" | "top" | "middle" | "bottom";
-export type DistributionKind = "horizontal" | "vertical" | "vertical-stack";
+export type DistributionKind = "horizontal" | "vertical" | "vertical-stack" | "horizontal-stack";
 
 const EPSILON = 1e-3;
 
@@ -155,10 +155,15 @@ export function alignSelectedNodes(nodes: Node[], selectedIds: Set<string>, alig
 
 const STACK_GAP = 1;
 
+function resolveStackSize(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 1;
+}
+
 export function distributeSelectedNodes(nodes: Node[], selectedIds: Set<string>, distribution: DistributionKind): ArrangementResult {
   if (!selectedIds.size) return { nodes, changed: false };
   const selected = nodes.filter((node) => selectedIds.has(node.id));
-  if (selected.length <= 2) return { nodes, changed: false };
+  const minSelection = distribution === "vertical-stack" || distribution === "horizontal-stack" ? 2 : 3;
+  if (selected.length < minSelection) return { nodes, changed: false };
 
   const indexMap = new Map<string, number>();
   nodes.forEach((node, index) => {
@@ -178,9 +183,9 @@ export function distributeSelectedNodes(nodes: Node[], selectedIds: Set<string>,
 
   let attempted = false;
   grouped.forEach((metrics) => {
-    if (metrics.length <= 2) return;
-    attempted = true;
     if (distribution === "horizontal") {
+      if (metrics.length <= 2) return;
+      attempted = true;
       const sorted = [...metrics].sort((a, b) => a.left - b.left);
       const first = sorted[0];
       const last = sorted[sorted.length - 1];
@@ -205,6 +210,8 @@ export function distributeSelectedNodes(nodes: Node[], selectedIds: Set<string>,
       const appliedFirst = replaceNode(nextNodes, indexMap, first, { x: start, y: first.top });
       if (appliedFirst) changed = true;
     } else if (distribution === "vertical") {
+      if (metrics.length <= 2) return;
+      attempted = true;
       const sorted = [...metrics].sort((a, b) => a.top - b.top);
       const first = sorted[0];
       const last = sorted[sorted.length - 1];
@@ -229,13 +236,26 @@ export function distributeSelectedNodes(nodes: Node[], selectedIds: Set<string>,
       const appliedFirst = replaceNode(nextNodes, indexMap, first, { x: first.left, y: start });
       if (appliedFirst) changed = true;
     } else if (distribution === "vertical-stack") {
+      if (metrics.length <= 1) return;
+      attempted = true;
       const sorted = [...metrics].sort((a, b) => a.top - b.top || a.left - b.left);
-      if (sorted.length === 0) return;
+      const baseX = Math.min(...sorted.map((metric) => metric.left));
       let cursor = Math.min(...sorted.map((metric) => metric.top));
       for (const metric of sorted) {
-        const applied = replaceNode(nextNodes, indexMap, metric, { x: metric.left, y: cursor });
+        const applied = replaceNode(nextNodes, indexMap, metric, { x: baseX, y: cursor });
         if (applied) changed = true;
-        cursor += metric.height + STACK_GAP;
+        cursor += resolveStackSize(metric.height) + STACK_GAP;
+      }
+    } else if (distribution === "horizontal-stack") {
+      if (metrics.length <= 1) return;
+      attempted = true;
+      const sorted = [...metrics].sort((a, b) => a.left - b.left || a.top - b.top);
+      const baseY = Math.min(...sorted.map((metric) => metric.top));
+      let cursor = Math.min(...sorted.map((metric) => metric.left));
+      for (const metric of sorted) {
+        const applied = replaceNode(nextNodes, indexMap, metric, { x: cursor, y: baseY });
+        if (applied) changed = true;
+        cursor += resolveStackSize(metric.width) + STACK_GAP;
       }
     }
   });

--- a/src/core/ui/arrange.ts
+++ b/src/core/ui/arrange.ts
@@ -1,7 +1,7 @@
 import type { Node, XYPosition } from "@xyflow/react";
 
 export type AlignmentKind = "left" | "center" | "right" | "top" | "middle" | "bottom";
-export type DistributionKind = "horizontal" | "vertical";
+export type DistributionKind = "horizontal" | "vertical" | "vertical-stack";
 
 const EPSILON = 1e-3;
 
@@ -153,6 +153,8 @@ export function alignSelectedNodes(nodes: Node[], selectedIds: Set<string>, alig
   return { nodes: changed ? nextNodes : nodes, changed };
 }
 
+const STACK_GAP = 1;
+
 export function distributeSelectedNodes(nodes: Node[], selectedIds: Set<string>, distribution: DistributionKind): ArrangementResult {
   if (!selectedIds.size) return { nodes, changed: false };
   const selected = nodes.filter((node) => selectedIds.has(node.id));
@@ -202,7 +204,7 @@ export function distributeSelectedNodes(nodes: Node[], selectedIds: Set<string>,
       if (appliedLast) changed = true;
       const appliedFirst = replaceNode(nextNodes, indexMap, first, { x: start, y: first.top });
       if (appliedFirst) changed = true;
-    } else {
+    } else if (distribution === "vertical") {
       const sorted = [...metrics].sort((a, b) => a.top - b.top);
       const first = sorted[0];
       const last = sorted[sorted.length - 1];
@@ -226,6 +228,15 @@ export function distributeSelectedNodes(nodes: Node[], selectedIds: Set<string>,
       if (appliedLast) changed = true;
       const appliedFirst = replaceNode(nextNodes, indexMap, first, { x: first.left, y: start });
       if (appliedFirst) changed = true;
+    } else if (distribution === "vertical-stack") {
+      const sorted = [...metrics].sort((a, b) => a.top - b.top || a.left - b.left);
+      if (sorted.length === 0) return;
+      let cursor = Math.min(...sorted.map((metric) => metric.top));
+      for (const metric of sorted) {
+        const applied = replaceNode(nextNodes, indexMap, metric, { x: metric.left, y: cursor });
+        if (applied) changed = true;
+        cursor += metric.height + STACK_GAP;
+      }
     }
   });
 

--- a/src/core/ui/arrange.ts
+++ b/src/core/ui/arrange.ts
@@ -186,8 +186,8 @@ export function alignSelectedNodes(nodes: Node[], selectedIds: Set<string>, alig
   return { nodes: changed ? nextNodes : nodes, changed };
 }
 
-const VERTICAL_STACK_GAP = 1;
-const HORIZONTAL_STACK_GAP = 15;
+const VERTICAL_STACK_GAP = 5;
+const HORIZONTAL_STACK_GAP = 25;
 
 function resolveStackSize(value: number): number {
   return Number.isFinite(value) && value > 0 ? value : 1;

--- a/src/core/ui/arrange.ts
+++ b/src/core/ui/arrange.ts
@@ -186,7 +186,8 @@ export function alignSelectedNodes(nodes: Node[], selectedIds: Set<string>, alig
   return { nodes: changed ? nextNodes : nodes, changed };
 }
 
-const STACK_GAP = 1;
+const VERTICAL_STACK_GAP = 1;
+const HORIZONTAL_STACK_GAP = 15;
 
 function resolveStackSize(value: number): number {
   return Number.isFinite(value) && value > 0 ? value : 1;
@@ -277,7 +278,7 @@ export function distributeSelectedNodes(nodes: Node[], selectedIds: Set<string>,
       for (const metric of sorted) {
         const applied = replaceNode(nextNodes, indexMap, metric, { x: baseX, y: cursor });
         if (applied) changed = true;
-        cursor += resolveStackSize(metric.height) + STACK_GAP;
+        cursor += resolveStackSize(metric.height) + VERTICAL_STACK_GAP;
       }
     } else if (distribution === "horizontal-stack") {
       if (metrics.length <= 1) return;
@@ -288,7 +289,7 @@ export function distributeSelectedNodes(nodes: Node[], selectedIds: Set<string>,
       for (const metric of sorted) {
         const applied = replaceNode(nextNodes, indexMap, metric, { x: cursor, y: baseY });
         if (applied) changed = true;
-        cursor += resolveStackSize(metric.width) + STACK_GAP;
+        cursor += resolveStackSize(metric.width) + HORIZONTAL_STACK_GAP;
       }
     }
   });

--- a/src/core/ui/useGraphHistory.ts
+++ b/src/core/ui/useGraphHistory.ts
@@ -39,7 +39,8 @@ export type GraphActionType =
   | "align-middle"
   | "distribute-horizontal"
   | "distribute-vertical"
-  | "distribute-vertical-stack";
+  | "distribute-vertical-stack"
+  | "distribute-horizontal-stack";
 
 export type GraphActionMeta = {
   type: GraphActionType;

--- a/src/core/ui/useGraphHistory.ts
+++ b/src/core/ui/useGraphHistory.ts
@@ -38,7 +38,8 @@ export type GraphActionType =
   | "align-center"
   | "align-middle"
   | "distribute-horizontal"
-  | "distribute-vertical";
+  | "distribute-vertical"
+  | "distribute-vertical-stack";
 
 export type GraphActionMeta = {
   type: GraphActionType;


### PR DESCRIPTION
## Summary
- standardize the graph context menu styling and remove disabled menu entries
- tighten spacing and dynamically size the menu to match the widest option
- keep arrangement actions available only when their operations are possible

## Testing
- bun run gates

------
https://chatgpt.com/codex/tasks/task_e_68e8c2b011c08332a61ebaa9280fe838