### PR TITLE
fix: align connection preview curve type

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3439,7 +3439,7 @@ export function App() {
                   setMenuPaletteOverride(null);
                   setMenu({ open: true, kind: "edge", x: e.clientX, y: e.clientY, targetId: edge.id });
                 }}
-                connectionLineType={curveMode === "default" ? "smoothstep" : curveMode as any}
+                connectionLineType={curveMode === "default" ? "default" : (curveMode as any)}
                 fitView
               >
                 <Background />

--- a/src/ui/settings/SettingsPage.tsx
+++ b/src/ui/settings/SettingsPage.tsx
@@ -780,7 +780,7 @@ function CurveModePreview({ curveMode }: { curveMode: CurveMode }) {
             edges={edges}
             edgeTypes={edgeTypes}
             defaultEdgeOptions={{ type: "colored" as any }}
-            connectionLineType={curveMode === "default" ? "smoothstep" : curveMode as any}
+            connectionLineType={curveMode === "default" ? "default" : (curveMode as any)}
             nodesDraggable={false}
             nodesConnectable={false}
             elementsSelectable={false}


### PR DESCRIPTION
## Summary
- ensure the ReactFlow connection preview uses the selected curve mode in the main editor and settings preview

## Testing
- bun run gates

------
https://chatgpt.com/codex/tasks/task_e_68eeab6b8e788332b5bca628f1b57581