### PR TITLE
fix: inline node alias metadata

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -6,6 +6,7 @@ import { rm, cp, mkdir, writeFile, readdir, readFile, stat } from "fs/promises";
 import path from "path";
 import { gzipSync, brotliCompressSync, constants as zlibConstants } from "zlib";
 import { validateLanguagePack, validateNodeTemplate } from "./src/core/schema/validators";
+import { extractNodeAliases } from "./src/core/schema/nodeMeta";
 import { getDeployLabel } from "./src/core/env/getDeployLabel";
 
 // Print help text if requested
@@ -280,7 +281,7 @@ async function* walk(dir: string, prefix = ""): AsyncGenerator<{ rel: string; ab
 async function generateNodesIndex() {
   const root = path.resolve(process.cwd(), "data", "nodes");
   if (!existsSync(root)) return;
-  const items: Array<{ type: string; name: string; path: string; category: string }> = [];
+  const items: Array<{ type: string; name: string; path: string; category: string; aliases?: string[] }> = [];
   for await (const entry of walk(root)) {
     if (entry.isDir) continue;
     if (!entry.rel.endsWith(".json")) continue;
@@ -292,18 +293,28 @@ async function generateNodesIndex() {
       const name = String(json.name ?? type);
       const rel = entry.rel;
       const category = rel.includes(path.sep) ? (rel.split(path.sep)[0] ?? "root") : "root";
-      items.push({ type, name, path: rel, category });
+      const aliases = extractNodeAliases(json.meta);
+      const item = { type, name, path: rel, category } as {
+        type: string;
+        name: string;
+        path: string;
+        category: string;
+        aliases?: string[];
+      };
+      if (aliases.length > 0) item.aliases = aliases;
+      items.push(item);
     } catch (_err) { /* ignore invalid node template */ }
   }
-  const categories: Record<string, typeof items> = {};
-  for (const it of items) (categories[it.category] ??= []).push(it);
+  const enriched = items;
+  const categories: Record<string, typeof enriched> = {};
+  for (const it of enriched) (categories[it.category] ??= []).push(it);
   const orderedCategories = Object.keys(categories)
     .sort((a, b) => a.localeCompare(b))
     .map((name) => ({
       name,
       nodes: (categories[name] ?? []).map((n) => ({ ...n, path: n.path })).sort((a, b) => a.name.localeCompare(b.name)),
     }));
-  const out = { categories: orderedCategories, flat: items.sort((a, b) => a.name.localeCompare(b.name)) };
+  const out = { categories: orderedCategories, flat: enriched.sort((a, b) => a.name.localeCompare(b.name)) };
   const outDir = path.join(outdir, "data");
   if (!existsSync(outDir)) await mkdir(outDir, { recursive: true });
   await writeFile(path.join(outDir, "nodes.index.json"), JSON.stringify(out, null, 2), "utf8");

--- a/data/nodes/constants/float2.json
+++ b/data/nodes/constants/float2.json
@@ -2,7 +2,13 @@
   "id": -1,
   "type": "float2",
   "name": "Float2",
-  "meta": [],
+  "meta": [
+    {
+      "aliases": [
+        "vector2"
+      ]
+    }
+  ],
   "position": [
     0,
     0

--- a/data/nodes/constants/float3.json
+++ b/data/nodes/constants/float3.json
@@ -2,7 +2,13 @@
   "id": -1,
   "type": "float3",
   "name": "Float3",
-  "meta": [],
+  "meta": [
+    {
+      "aliases": [
+        "vector3"
+      ]
+    }
+  ],
   "position": [
     0,
     0

--- a/data/nodes/constants/float4.json
+++ b/data/nodes/constants/float4.json
@@ -2,7 +2,13 @@
   "id": -1,
   "type": "float4",
   "name": "Float4",
-  "meta": [],
+  "meta": [
+    {
+      "aliases": [
+        "vector4"
+      ]
+    }
+  ],
   "position": [
     0,
     0

--- a/data/nodes/math/combine2.json
+++ b/data/nodes/math/combine2.json
@@ -2,7 +2,16 @@
   "id": -1,
   "type": "combine2",
   "name": "Combine 2",
-  "meta": [],
+  "meta": [
+    {
+      "aliases": [
+        "merge",
+        "combine vector2",
+        "compose",
+        "join"
+      ]
+    }
+  ],
   "position": [
     0,
     0

--- a/data/nodes/math/combine2.json
+++ b/data/nodes/math/combine2.json
@@ -6,7 +6,6 @@
     {
       "aliases": [
         "merge",
-        "combine vector2",
         "compose",
         "join"
       ]

--- a/data/nodes/math/combine3.json
+++ b/data/nodes/math/combine3.json
@@ -2,7 +2,16 @@
   "id": -1,
   "type": "combine3",
   "name": "Combine 3",
-  "meta": [],
+  "meta": [
+    {
+      "aliases": [
+        "merge",
+        "combine vector3",
+        "compose",
+        "join"
+      ]
+    }
+  ],
   "position": [
     0,
     0

--- a/data/nodes/math/combine3.json
+++ b/data/nodes/math/combine3.json
@@ -6,7 +6,6 @@
     {
       "aliases": [
         "merge",
-        "combine vector3",
         "compose",
         "join"
       ]

--- a/data/nodes/math/combine4.json
+++ b/data/nodes/math/combine4.json
@@ -2,7 +2,16 @@
   "id": -1,
   "type": "combine4",
   "name": "Combine 4",
-  "meta": [],
+  "meta": [
+    {
+      "aliases": [
+        "merge",
+        "combine vector4",
+        "compose",
+        "join"
+      ]
+    }
+  ],
   "position": [
     0,
     0

--- a/data/nodes/math/combine4.json
+++ b/data/nodes/math/combine4.json
@@ -6,7 +6,6 @@
     {
       "aliases": [
         "merge",
-        "combine vector4",
         "compose",
         "join"
       ]

--- a/data/nodes/math/separate2.json
+++ b/data/nodes/math/separate2.json
@@ -2,7 +2,16 @@
   "id": -1,
   "type": "separate2",
   "name": "Separate 2",
-  "meta": [],
+  "meta": [
+    {
+      "aliases": [
+        "split",
+        "split vector2",
+        "decompose",
+        "separate xy"
+      ]
+    }
+  ],
   "position": [
     0,
     0

--- a/data/nodes/math/separate2.json
+++ b/data/nodes/math/separate2.json
@@ -6,7 +6,6 @@
     {
       "aliases": [
         "split",
-        "split vector2",
         "decompose",
         "separate xy"
       ]

--- a/data/nodes/math/separate3.json
+++ b/data/nodes/math/separate3.json
@@ -6,7 +6,6 @@
     {
       "aliases": [
         "split",
-        "split vector3",
         "decompose",
         "separate xyz"
       ]

--- a/data/nodes/math/separate3.json
+++ b/data/nodes/math/separate3.json
@@ -2,7 +2,16 @@
   "id": -1,
   "type": "separate3",
   "name": "Separate 3",
-  "meta": [],
+  "meta": [
+    {
+      "aliases": [
+        "split",
+        "split vector3",
+        "decompose",
+        "separate xyz"
+      ]
+    }
+  ],
   "position": [
     0,
     0

--- a/data/nodes/math/separate4.json
+++ b/data/nodes/math/separate4.json
@@ -6,7 +6,6 @@
     {
       "aliases": [
         "split",
-        "split vector4",
         "decompose",
         "separate rgba"
       ]

--- a/data/nodes/math/separate4.json
+++ b/data/nodes/math/separate4.json
@@ -2,7 +2,16 @@
   "id": -1,
   "type": "separate4",
   "name": "Separate 4",
-  "meta": [],
+  "meta": [
+    {
+      "aliases": [
+        "split",
+        "split vector4",
+        "decompose",
+        "separate rgba"
+      ]
+    }
+  ],
   "position": [
     0,
     0

--- a/src/components/GraphContextMenu.tsx
+++ b/src/components/GraphContextMenu.tsx
@@ -219,7 +219,10 @@ export function GraphContextMenu(props: GraphContextMenuProps) {
     // When searching, show flat node list with category labels
     if (q) {
       const matches = palette.flat
-        .filter((n) => [n.name, n.type, n.category].some((s) => s.toLowerCase().includes(q)))
+        .filter((n) => {
+          const tokens = [n.name, n.type, n.category, ...(n.aliases ?? [])];
+          return tokens.some((s) => s.toLowerCase().includes(q));
+        })
         .sort((a, b) => a.name.localeCompare(b.name) || a.category.localeCompare(b.category));
       return matches.map((n) => ({ kind: "node", key: `${n.category}/${n.type}`, node: n }));
     }

--- a/src/core/schema/__tests__/nodeMeta.test.ts
+++ b/src/core/schema/__tests__/nodeMeta.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { extractNodeAliases } from "../nodeMeta";
+
+describe("extractNodeAliases", () => {
+  it("returns an empty array when meta is not an array", () => {
+    expect(extractNodeAliases(undefined)).toEqual([]);
+    expect(extractNodeAliases(null)).toEqual([]);
+    expect(extractNodeAliases({})).toEqual([]);
+  });
+
+  it("extracts aliases from object metadata", () => {
+    const result = extractNodeAliases([
+      { aliases: ["split", "decompose"] },
+      { alias: "join" },
+      { searchAliases: ["merge"] },
+    ]);
+    expect(result.sort()).toEqual(["decompose", "join", "merge", "split"]);
+  });
+
+  it("deduplicates aliases and trims values", () => {
+    const result = extractNodeAliases([
+      { aliases: [" split", "split", ""] },
+      "alias:compose ",
+      { search_terms: ["compose", " join "] },
+      42,
+    ]);
+    expect(result.sort()).toEqual(["compose", "join", "split"]);
+  });
+
+  it("ignores malformed entries", () => {
+    const result = extractNodeAliases([
+      { aliases: ["", null, undefined] },
+      { alias: 123 },
+      { search_aliases: [Symbol("noop")] },
+    ] as any);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/core/schema/nodeMeta.ts
+++ b/src/core/schema/nodeMeta.ts
@@ -1,0 +1,43 @@
+export function extractNodeAliases(meta: unknown): string[] {
+  if (!Array.isArray(meta)) return [];
+
+  const aliases = new Set<string>();
+
+  for (const entry of meta) {
+    if (typeof entry === "string") {
+      const trimmed = entry.trim();
+      if (!trimmed) continue;
+      const prefix = "alias:";
+      if (trimmed.toLowerCase().startsWith(prefix)) {
+        const alias = trimmed.slice(prefix.length).trim();
+        if (alias) aliases.add(alias);
+      }
+      continue;
+    }
+
+    if (!entry || typeof entry !== "object") continue;
+
+    const container = entry as Record<string, unknown>;
+    const rawList =
+      container.aliases ??
+      container.alias ??
+      container.search_aliases ??
+      container.searchAliases ??
+      container.search_terms ??
+      container.searchTerms;
+
+    const values = Array.isArray(rawList)
+      ? rawList
+      : typeof rawList === "string"
+        ? [rawList]
+        : [];
+
+    for (const value of values) {
+      if (typeof value !== "string") continue;
+      const alias = value.trim();
+      if (alias) aliases.add(alias);
+    }
+  }
+
+  return Array.from(aliases);
+}

--- a/src/core/schema/types.ts
+++ b/src/core/schema/types.ts
@@ -55,6 +55,7 @@ export type NodePaletteItem = {
   name: string;
   path: string; // relative to data/nodes
   category: string; // folder name or 'root'
+  aliases?: string[];
 };
 
 export type NodePalette = {

--- a/src/server/nodes.ts
+++ b/src/server/nodes.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "fs";
 import path from "path";
+import { extractNodeAliases } from "../core/schema/nodeMeta";
 
 export async function nodesListHandler(): Promise<Response> {
   try {
@@ -13,7 +14,7 @@ export async function nodesListHandler(): Promise<Response> {
       return Response.json({ error: "OSG data missing: 'data/nodes' directory not found" }, { status: 500 });
     }
 
-    const items: Array<{ type: string; name: string; path: string; category: string }> = [];
+    const items: Array<{ type: string; name: string; path: string; category: string; aliases?: string[] }> = [];
     async function walk(dir: string, prefix = ""): Promise<void> {
       const entries = await fs.readdir(dir, { withFileTypes: true } as any);
       for (const e of entries as any[]) {
@@ -31,7 +32,16 @@ export async function nodesListHandler(): Promise<Response> {
             // Determine category from directory segment, not filename
             const dirPart = prefix ? prefix.split(path.sep)[0] : "";
             const category = dirPart || "root";
-            items.push({ type, name, path: rel, category });
+            const aliases = extractNodeAliases(json.meta);
+            const item = { type, name, path: rel, category } as {
+              type: string;
+              name: string;
+              path: string;
+              category: string;
+              aliases?: string[];
+            };
+            if (aliases.length > 0) item.aliases = aliases;
+            items.push(item);
           } catch (err) {
             console.warn("Failed parsing node template:", rel, err);
           }
@@ -40,8 +50,10 @@ export async function nodesListHandler(): Promise<Response> {
     }
     await walk(root);
 
-    const categories: Record<string, typeof items> = {};
-    for (const it of items) {
+    const enriched = items;
+
+    const categories: Record<string, typeof enriched> = {};
+    for (const it of enriched) {
       const key = it.category ?? "root";
       (categories[key] ??= []).push(it);
     }
@@ -57,7 +69,7 @@ export async function nodesListHandler(): Promise<Response> {
 
     return Response.json({
       categories: orderedCategories,
-      flat: items.sort((a, b) => a.name.localeCompare(b.name)),
+      flat: enriched.sort((a, b) => a.name.localeCompare(b.name)),
     });
   } catch (err) {
     console.error("/api/nodes failed:", err);

--- a/tests/graph_context_menu.spec.tsx
+++ b/tests/graph_context_menu.spec.tsx
@@ -1,0 +1,50 @@
+/* @vitest-environment jsdom */
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { GraphContextMenu } from "@/components/GraphContextMenu";
+import type { NodePalette, NodePaletteItem } from "@/core/schema/types";
+
+beforeEach(() => {
+  // JSDOM lacks this method which our component calls when scrolling
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe("GraphContextMenu search", () => {
+  const baseNode: NodePaletteItem = {
+    type: "separate3",
+    name: "Separate 3",
+    path: "math/separate3.json",
+    category: "math",
+    aliases: ["split", "decompose"],
+  };
+
+  const palette: NodePalette = {
+    categories: [
+      {
+        name: "math",
+        nodes: [baseNode],
+      },
+    ],
+    flat: [baseNode],
+  };
+
+  it("matches nodes by alias when searching", () => {
+    render(
+      <GraphContextMenu
+        open
+        kind="background"
+        x={100}
+        y={100}
+        palette={palette}
+        onClose={() => {}}
+      />
+    );
+
+    const input = screen.getByPlaceholderText("Search nodes…");
+    fireEvent.change(input, { target: { value: "split" } });
+
+    expect(screen.queryByText("Separate 3")).not.toBeNull();
+    cleanup();
+  });
+});


### PR DESCRIPTION
## Summary
- embed alias search terms directly into the combine and separate node templates so they travel with the source data
- add a shared helper to extract alias metadata and use it for the build output and node API payloads
- cover alias extraction logic with a focused unit test

## Testing
- bun run gates

------
https://chatgpt.com/codex/tasks/task_e_68eec15466b08332b9e31bd66bc6c2fb