### PR TITLE
Restrict semantic-release to dev branch

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -35,10 +35,7 @@ function resolveContributor(commit) {
 }
 
 export default {
-  branches: [
-    { name: "dev" },
-    { name: "beta", prerelease: "beta" },
-  ],
+  branches: [{ name: "dev" }],
   repositoryUrl: "https://github.com/omid3098/openshadergraph",
   plugins: [
     ["@semantic-release/commit-analyzer", { preset: "conventionalcommits" }],


### PR DESCRIPTION
## Summary
- update the semantic-release configuration so that only the dev branch performs version bumps

## Testing
- bun run gates

------
https://chatgpt.com/codex/tasks/task_e_68ef4f01c17483329ab9e308bebba2a2