### PR TITLE
feat: pin editor panels to viewport

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,11 @@ import {
 } from "./core/ui/nodeUpdaters";
 import { GraphStateProvider } from "./core/ui/GraphStateContext";
 import {
+  EditorPanelLayoutProvider,
+  type EditorPanelLayout,
+  type EditorPanelLayoutPatch,
+} from "./core/ui/EditorPanelLayoutContext";
+import {
   SettingsProvider,
   type CurveMode,
   type ThemeName,
@@ -130,6 +135,33 @@ function normalizeActionHotkeys(value?: ActionHotkeys | null): ActionHotkeys {
   const code = typeof value?.quickExportCode === "string" ? value.quickExportCode.trim() : "";
   const normalized = code.length ? code : DEFAULT_ACTION_HOTKEYS.quickExportCode;
   return { quickExportCode: normalized };
+}
+
+const EDITOR_PANEL_LAYOUT_STORAGE_KEY = "ui.editorPanels";
+
+function sanitizeEditorPanelLayouts(
+  value: unknown
+): Partial<Record<EditorPanelKey, EditorPanelLayout>> {
+  if (!value || typeof value !== "object") return {};
+  const result: Partial<Record<EditorPanelKey, EditorPanelLayout>> = {};
+  const entries = Object.keys(EDITOR_PANEL_TYPES) as EditorPanelKey[];
+  const parseCoordinate = (coord: unknown): number => {
+    if (typeof coord === "number" && Number.isFinite(coord)) return coord;
+    if (typeof coord === "string") {
+      const parsed = Number.parseFloat(coord);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+    return 0;
+  };
+  for (const key of entries) {
+    const raw = (value as Record<string, unknown>)[key];
+    if (!raw || typeof raw !== "object") continue;
+    const pinned = Boolean((raw as any).pinned);
+    const viewportX = parseCoordinate((raw as any).viewportX);
+    const viewportY = parseCoordinate((raw as any).viewportY);
+    result[key] = { pinned, viewportX, viewportY };
+  }
+  return result;
 }
 
 const ALIGNMENT_LABELS: Record<AlignmentKind, string> = {
@@ -278,6 +310,9 @@ export function App() {
   const [canQuickExport, setCanQuickExport] = useState(false);
   const quickExportHandleRef = useRef<FileSystemFileHandle | null>(null);
   const quickExportLanguageRef = useRef<string | null>(null);
+  const [editorPanelLayouts, setEditorPanelLayouts] = useState<
+    Partial<Record<EditorPanelKey, EditorPanelLayout>>
+  >({});
   const setQuickExportState = useCallback(
     (handle: FileSystemFileHandle | null, language: string | null) => {
       quickExportHandleRef.current = handle;
@@ -358,6 +393,68 @@ export function App() {
     if (!quickHotkeysPersistReadyRef.current) return;
     void persistSet("ui.quickNodeHotkeys", quickNodeHotkeys);
   }, [quickNodeHotkeys]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const stored = await persistGet<Partial<Record<EditorPanelKey, EditorPanelLayout>>>(
+        EDITOR_PANEL_LAYOUT_STORAGE_KEY
+      );
+      if (cancelled) return;
+      if (stored && typeof stored === "object") {
+        const sanitized = sanitizeEditorPanelLayouts(stored);
+        if (Object.keys(sanitized).length) {
+          setEditorPanelLayouts((prev) => ({ ...sanitized, ...prev }));
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const updateEditorPanelLayout = useCallback(
+    (panel: EditorPanelKey, patch: EditorPanelLayoutPatch | null) => {
+      if (!panel) return;
+      setEditorPanelLayouts((prev) => {
+        const previous = prev[panel];
+        if (patch === null) {
+          if (!(panel in prev)) return prev;
+          const { [panel]: _removed, ...rest } = prev;
+          const next = rest as Partial<Record<EditorPanelKey, EditorPanelLayout>>;
+          void persistSet(EDITOR_PANEL_LAYOUT_STORAGE_KEY, next);
+          return next;
+        }
+        const resolved = typeof patch === "function" ? patch(previous) : patch;
+        if (!resolved) return prev;
+        const coerce = (value: unknown, fallback: number): number => {
+          if (typeof value === "number" && Number.isFinite(value)) return value;
+          if (typeof value === "string") {
+            const parsed = Number.parseFloat(value);
+            if (Number.isFinite(parsed)) return parsed;
+          }
+          return fallback;
+        };
+        const nextLayout: EditorPanelLayout = {
+          pinned: resolved.pinned ?? previous?.pinned ?? false,
+          viewportX: coerce(resolved.viewportX, previous?.viewportX ?? 0),
+          viewportY: coerce(resolved.viewportY, previous?.viewportY ?? 0),
+        };
+        if (
+          previous &&
+          previous.pinned === nextLayout.pinned &&
+          previous.viewportX === nextLayout.viewportX &&
+          previous.viewportY === nextLayout.viewportY
+        ) {
+          return prev;
+        }
+        const next = { ...prev, [panel]: nextLayout } as Partial<Record<EditorPanelKey, EditorPanelLayout>>;
+        void persistSet(EDITOR_PANEL_LAYOUT_STORAGE_KEY, next);
+        return next;
+      });
+    },
+    []
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -1413,6 +1510,14 @@ export function App() {
   }, [nodes]);
 
   const selectedCount = useMemo(() => nodes.filter((node) => node.selected).length, [nodes]);
+
+  const editorPanelLayoutValue = useMemo(
+    () => ({
+      layouts: editorPanelLayouts,
+      updateLayout: updateEditorPanelLayout,
+    }),
+    [editorPanelLayouts, updateEditorPanelLayout]
+  );
 
   const graphStateValue = useMemo(
     () => ({
@@ -3310,12 +3415,13 @@ export function App() {
 
   return (
     <SettingsProvider value={settingsValue}>
-      <GraphStateProvider value={graphStateValue}>
-        <AppShell
-          header={Header}
-          sidebarContent={renderSidebar}
-          theme={theme}
-          onToggleTheme={toggleTheme}
+      <EditorPanelLayoutProvider value={editorPanelLayoutValue}>
+        <GraphStateProvider value={graphStateValue}>
+          <AppShell
+            header={Header}
+            sidebarContent={renderSidebar}
+            theme={theme}
+            onToggleTheme={toggleTheme}
         >
           {activeView === "settings" ? (
             <SettingsPage
@@ -3577,7 +3683,8 @@ export function App() {
             </div>
           )}
         </AppShell>
-      </GraphStateProvider>
+        </GraphStateProvider>
+      </EditorPanelLayoutProvider>
     </SettingsProvider>
   );
 }

--- a/src/components/GraphNode.tsx
+++ b/src/components/GraphNode.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, type CSSProperties } from "react";
+import { useCallback, useEffect, useMemo, useRef, type CSSProperties } from "react";
 import type { Node as RFNode, NodeProps } from "@xyflow/react";
 import { Handle, NodeResizer, Position, useNodeId, useStore } from "@xyflow/react";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
@@ -125,8 +125,15 @@ export function GraphNode({ data, selected }: NodeProps<RFNode<GraphNodeData>>) 
     : 1;
   const isPinned = Boolean(isEditor && editorLayout?.pinned);
   const canPin = Boolean(normalizedEditorPanelKey);
+  const nodeInternal = useStore((state) =>
+    nodeId ? state.nodeLookup.get(nodeId) : undefined
+  );
+  const isDragging = Boolean(nodeInternal?.dragging);
+  const isResizing = Boolean(nodeInternal?.resizing);
+  const isPinnedInteracting = Boolean(isPinned && (isDragging || isResizing));
+
   const pinnedStyle = useMemo<CSSProperties | undefined>(() => {
-    if (!isPinned || !isEditor) return undefined;
+    if (!isPinned || !isEditor || isPinnedInteracting) return undefined;
     const targetX = Number.isFinite(editorLayout?.viewportX)
       ? (editorLayout?.viewportX as number)
       : viewportX + viewportZoom * positionX;
@@ -153,6 +160,7 @@ export function GraphNode({ data, selected }: NodeProps<RFNode<GraphNodeData>>) 
     viewportZoom,
     positionX,
     positionY,
+    isPinnedInteracting,
   ]);
 
   const handleTogglePin = useCallback(
@@ -178,6 +186,33 @@ export function GraphNode({ data, selected }: NodeProps<RFNode<GraphNodeData>>) 
       positionY,
     ]
   );
+
+  const wasInteractingRef = useRef(false);
+  useEffect(() => {
+    if (!isPinned || !normalizedEditorPanelKey) {
+      wasInteractingRef.current = false;
+      return;
+    }
+    const wasInteracting = wasInteractingRef.current;
+    if (wasInteracting && !isPinnedInteracting) {
+      const nextViewportX = viewportX + viewportZoom * positionX;
+      const nextViewportY = viewportY + viewportZoom * positionY;
+      if (Number.isFinite(nextViewportX) && Number.isFinite(nextViewportY)) {
+        updateEditorLayout({ pinned: true, viewportX: nextViewportX, viewportY: nextViewportY });
+      }
+    }
+    wasInteractingRef.current = isPinnedInteracting;
+  }, [
+    isPinned,
+    isPinnedInteracting,
+    normalizedEditorPanelKey,
+    positionX,
+    positionY,
+    updateEditorLayout,
+    viewportX,
+    viewportY,
+    viewportZoom,
+  ]);
   const preferredSize = isProbeWidget ? parseEditorSize(meta) : {};
   const preferredWidth = preferredSize.width;
   const preferredHeight = preferredSize.height;
@@ -555,31 +590,17 @@ export function GraphNode({ data, selected }: NodeProps<RFNode<GraphNodeData>>) 
           className={cn("h-full flex flex-col", ringBaseClass, ringClass)}
           style={cardRingVars}
           onPointerDownCapture={(event) => {
-            if (isPinned) {
-              const targetEl = event.target instanceof Element ? event.target : null;
-              if (targetEl && targetEl.closest(".node-drag-handle")) {
-                event.stopPropagation();
-                event.preventDefault();
-                return;
-              }
-            }
             if (shouldBlockNodePointer(event.target)) {
               event.stopPropagation();
             }
           }}
         >
           <CardHeader
-            className="py-2 px-3 node-drag-handle cursor-grab active:cursor-grabbing flex items-center justify-between"
+            className="py-2 px-3 node-drag-handle cursor-grab active:cursor-grabbing flex items-center gap-2"
             style={{
               ...headerStyle,
               borderTopLeftRadius: "inherit",
               borderTopRightRadius: "inherit",
-            }}
-            onPointerDownCapture={(event) => {
-              if (isPinned) {
-                event.stopPropagation();
-                event.preventDefault();
-              }
             }}
           >
             <div className="flex items-center gap-2">
@@ -588,7 +609,7 @@ export function GraphNode({ data, selected }: NodeProps<RFNode<GraphNodeData>>) 
             </div>
             <button
               type="button"
-              className="inline-flex h-6 w-6 items-center justify-center rounded-sm border border-white/20 bg-white/10 text-white/90 hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-40"
+              className="ml-auto inline-flex h-6 w-6 items-center justify-center rounded-sm border border-white/20 bg-white/10 text-white/90 hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-40"
               aria-label={isPinned ? "Unpin panel" : "Pin panel"}
               aria-pressed={isPinned}
               disabled={!canPin}

--- a/src/components/GraphNode.tsx
+++ b/src/components/GraphNode.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef, type CSSProperties } from "react";
 import type { Node as RFNode, NodeProps } from "@xyflow/react";
 import { Handle, NodeResizer, Position, useNodeId, useStore } from "@xyflow/react";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
@@ -22,9 +22,19 @@ const PreviewPanel = React.lazy(() => import("./PreviewPanel").then(m => ({ defa
 import { AssetsPanel } from "./AssetsPanel";
 import { ProbePreview } from "./ProbePreview";
 import { getBuiltinDisplayLabel, isBuiltinToken } from "@/core/types/builtinInputs";
-import { Paperclip, ArrowDownLeft, ArrowUpRight, SlidersHorizontal, PanelsTopLeft } from "lucide-react";
+import {
+  Paperclip,
+  ArrowDownLeft,
+  ArrowUpRight,
+  SlidersHorizontal,
+  PanelsTopLeft,
+  Pin as PinIcon,
+  PinOff,
+} from "lucide-react";
 import { parseEditorSize } from "@/core/ui/nodeFactory";
 import { ASSET_DRAG_MIME } from "@/core/assets/kind";
+import { useEditorPanelLayout } from "@/core/ui/EditorPanelLayoutContext";
+import type { EditorPanelKey } from "@/core/ui/editorNodes";
 
 type Pin = {
   id?: number;
@@ -82,7 +92,18 @@ export function GraphNode({ data, selected }: NodeProps<RFNode<GraphNodeData>>) 
   const nodeId = useNodeId();
   // Subscribe to edges so this node re-renders when connections change
   const edges = useStore((s) => s.edges);
-  const { nodeUpdaterApi, graph } = useGraphState();
+  const { nodeUpdaterApi, graph, nodesById } = useGraphState();
+  const nodePosition = useMemo(() => {
+    if (!nodeId) return { x: 0, y: 0 };
+    const entry = nodesById.get(nodeId);
+    if (!entry) return { x: 0, y: 0 };
+    const pos = entry.position ?? { x: 0, y: 0 };
+    const px = typeof pos?.x === "number" && Number.isFinite(pos.x) ? pos.x : 0;
+    const py = typeof pos?.y === "number" && Number.isFinite(pos.y) ? pos.y : 0;
+    return { x: px, y: py };
+  }, [nodeId, nodesById]);
+  const positionX = nodePosition.x;
+  const positionY = nodePosition.y;
   const meta: string[] = Array.isArray((data as any)?.template?.meta) ? (((data as any).template.meta as unknown) as string[]) : [];
   const editorPanel = meta.find((m) => typeof m === "string" && m.startsWith("editor_panel:"));
   const editorPanelKey = editorPanel ? editorPanel.split(":")[1] ?? "" : "";
@@ -90,6 +111,73 @@ export function GraphNode({ data, selected }: NodeProps<RFNode<GraphNodeData>>) 
   const editorWidgetKey = editorWidget ? editorWidget.split(":")[1] ?? "" : "";
   const isProbeWidget = editorWidgetKey.toLowerCase() === "probe";
   const isEditor = !isProbeWidget && meta.includes("editor_node");
+  const normalizedEditorPanelKey = useMemo(() => {
+    if (!isEditor) return undefined;
+    if (!editorPanelKey) return undefined;
+    return editorPanelKey as EditorPanelKey;
+  }, [isEditor, editorPanelKey]);
+  const { layout: editorLayout, updateLayout: updateEditorLayout } = useEditorPanelLayout(normalizedEditorPanelKey);
+  const transformState = useStore((state) => state.transform);
+  const viewportX = Array.isArray(transformState) && Number.isFinite(transformState[0]) ? transformState[0]! : 0;
+  const viewportY = Array.isArray(transformState) && Number.isFinite(transformState[1]) ? transformState[1]! : 0;
+  const viewportZoom = Array.isArray(transformState) && Number.isFinite(transformState[2]) && transformState[2]! > 0
+    ? transformState[2]!
+    : 1;
+  const isPinned = Boolean(isEditor && editorLayout?.pinned);
+  const canPin = Boolean(normalizedEditorPanelKey);
+  const pinnedStyle = useMemo<CSSProperties | undefined>(() => {
+    if (!isPinned || !isEditor) return undefined;
+    const targetX = Number.isFinite(editorLayout?.viewportX)
+      ? (editorLayout?.viewportX as number)
+      : viewportX + viewportZoom * positionX;
+    const targetY = Number.isFinite(editorLayout?.viewportY)
+      ? (editorLayout?.viewportY as number)
+      : viewportY + viewportZoom * positionY;
+    if (!Number.isFinite(targetX) || !Number.isFinite(targetY) || !Number.isFinite(viewportZoom) || viewportZoom <= 0) {
+      return undefined;
+    }
+    const invZoom = 1 / viewportZoom;
+    const translateX = (targetX - viewportZoom * positionX - viewportX) / viewportZoom;
+    const translateY = (targetY - viewportZoom * positionY - viewportY) / viewportZoom;
+    return {
+      transform: `matrix(${invZoom},0,0,${invZoom},${translateX},${translateY})`,
+      transformOrigin: "0 0",
+    } satisfies CSSProperties;
+  }, [
+    isEditor,
+    isPinned,
+    editorLayout?.viewportX,
+    editorLayout?.viewportY,
+    viewportX,
+    viewportY,
+    viewportZoom,
+    positionX,
+    positionY,
+  ]);
+
+  const handleTogglePin = useCallback(
+    (nextPinned: boolean) => {
+      if (!isEditor || !normalizedEditorPanelKey) return;
+      if (!nextPinned) {
+        updateEditorLayout({ pinned: false });
+        return;
+      }
+      const targetX = viewportX + viewportZoom * positionX;
+      const targetY = viewportY + viewportZoom * positionY;
+      if (!Number.isFinite(targetX) || !Number.isFinite(targetY)) return;
+      updateEditorLayout({ pinned: true, viewportX: targetX, viewportY: targetY });
+    },
+    [
+      isEditor,
+      normalizedEditorPanelKey,
+      updateEditorLayout,
+      viewportX,
+      viewportY,
+      viewportZoom,
+      positionX,
+      positionY,
+    ]
+  );
   const preferredSize = isProbeWidget ? parseEditorSize(meta) : {};
   const preferredWidth = preferredSize.width;
   const preferredHeight = preferredSize.height;
@@ -452,7 +540,11 @@ export function GraphNode({ data, selected }: NodeProps<RFNode<GraphNodeData>>) 
 
   if (isEditor) {
     return (
-      <div className="relative w-full h-full">
+      <div
+        className="relative w-full h-full"
+        style={pinnedStyle}
+        data-editor-pinned={isPinned ? "true" : undefined}
+      >
         <NodeResizer
           color={THEME.selectionColor}
           isVisible={selected}
@@ -463,23 +555,53 @@ export function GraphNode({ data, selected }: NodeProps<RFNode<GraphNodeData>>) 
           className={cn("h-full flex flex-col", ringBaseClass, ringClass)}
           style={cardRingVars}
           onPointerDownCapture={(event) => {
+            if (isPinned) {
+              const targetEl = event.target instanceof Element ? event.target : null;
+              if (targetEl && targetEl.closest(".node-drag-handle")) {
+                event.stopPropagation();
+                event.preventDefault();
+                return;
+              }
+            }
             if (shouldBlockNodePointer(event.target)) {
               event.stopPropagation();
             }
           }}
         >
           <CardHeader
-            className="py-2 px-3 node-drag-handle cursor-grab active:cursor-grabbing flex items-center"
+            className="py-2 px-3 node-drag-handle cursor-grab active:cursor-grabbing flex items-center justify-between"
             style={{
               ...headerStyle,
               borderTopLeftRadius: "inherit",
               borderTopRightRadius: "inherit",
+            }}
+            onPointerDownCapture={(event) => {
+              if (isPinned) {
+                event.stopPropagation();
+                event.preventDefault();
+              }
             }}
           >
             <div className="flex items-center gap-2">
               <PanelsTopLeft className="h-3.5 w-3.5 text-white/90" />
               <CardTitle className="text-sm text-white">{name}</CardTitle>
             </div>
+            <button
+              type="button"
+              className="inline-flex h-6 w-6 items-center justify-center rounded-sm border border-white/20 bg-white/10 text-white/90 hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-40"
+              aria-label={isPinned ? "Unpin panel" : "Pin panel"}
+              aria-pressed={isPinned}
+              disabled={!canPin}
+              title={isPinned ? "Unpin panel" : "Pin panel to viewport"}
+              onClick={(event) => {
+                event.stopPropagation();
+                event.preventDefault();
+                if (!canPin) return;
+                handleTogglePin(!isPinned);
+              }}
+            >
+              {isPinned ? <PinIcon className="h-3.5 w-3.5" /> : <PinOff className="h-3.5 w-3.5" />}
+            </button>
           </CardHeader>
           <CardContent className="p-0 flex-1 overflow-hidden">
             {renderEditorContent()}

--- a/src/core/ui/EditorPanelLayoutContext.tsx
+++ b/src/core/ui/EditorPanelLayoutContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, useCallback, useContext, type ReactNode } from "react";
+import type { EditorPanelKey } from "./editorNodes";
+
+export type EditorPanelLayout = {
+  pinned: boolean;
+  viewportX: number;
+  viewportY: number;
+};
+
+export type EditorPanelLayoutPatch =
+  | Partial<EditorPanelLayout>
+  | ((previous: EditorPanelLayout | undefined) => Partial<EditorPanelLayout> | undefined);
+
+type EditorPanelLayoutContextValue = {
+  layouts: Partial<Record<EditorPanelKey, EditorPanelLayout>>;
+  updateLayout: (panel: EditorPanelKey, patch: EditorPanelLayoutPatch | null) => void;
+};
+
+const EditorPanelLayoutContext = createContext<EditorPanelLayoutContextValue | null>(null);
+
+export function EditorPanelLayoutProvider({
+  value,
+  children,
+}: {
+  value: EditorPanelLayoutContextValue;
+  children: ReactNode;
+}) {
+  return <EditorPanelLayoutContext.Provider value={value}>{children}</EditorPanelLayoutContext.Provider>;
+}
+
+export function useEditorPanelLayout(panel?: EditorPanelKey) {
+  const ctx = useContext(EditorPanelLayoutContext);
+  const layout = panel && ctx ? ctx.layouts[panel] : undefined;
+  const updateLayout = useCallback(
+    (patch: EditorPanelLayoutPatch | null) => {
+      if (!panel || !ctx) return;
+      ctx.updateLayout(panel, patch);
+    },
+    [ctx, panel]
+  );
+  return { layout, updateLayout } as const;
+}


### PR DESCRIPTION
## Summary
- add a shared editor panel layout context that persists pinned viewport positions
- render editor panels with a pin control and viewport-relative transforms so pinned panels stay fixed while navigating
- load persisted layouts when graphs change and wrap the app with the layout provider so panels reuse their saved placement

## Testing
- bun run gates

------
https://chatgpt.com/codex/tasks/task_e_68f67267aab0833280e58d676bf087a3